### PR TITLE
Remove support for cogs

### DIFF
--- a/cogs/e
+++ b/cogs/e
@@ -1,1 +1,0 @@
-If you are seeing this, what are you doing here anyway? :eyes:

--- a/config/commands.json
+++ b/config/commands.json
@@ -76,7 +76,7 @@
       "cooldown": null,
       "args": ["module"],
       "usable_by": "the developer",
-      "disabled": false,
+      "disabled": true,
       "bugged": false
   },
   "unload": {
@@ -86,7 +86,7 @@
       "cooldown": null,
       "args": ["module"],
       "usable_by": "the developer",
-      "disabled": false,
+      "disabled": true,
       "bugged": false
   },
   "sync": {

--- a/main.py
+++ b/main.py
@@ -199,41 +199,41 @@ async def help(ctx:SlashContext, command:str=None):
         localembed = discord.Embed(title="Isobot Command Help", description=f"**Bot Commands:**\n{r}", color = discord.Color.random())
         await ctx.send(embed=localembed)
 
-@slash.slash(
-    name='load',
-    description='Loads the specified module to the bot',
-    options=[
-        create_option(name='module', description='Which module do you want to load? (only in cogs folder)', option_type=3, required=True)
-    ]
-)
-async def load(ctx:SlashContext, module:str):
-    if ctx.author.id != 738290097170153472: return ctx.send("Sorry, but this command is only for my developer's use.", hidden=True)
-    try:
-        utils.logger.info(f"Attempting to load module \"{module}\".")
-        client.load_extension(module)
-        utils.logger.info("Success loading module!")
-        await ctx.reply("Module loaded!")
-    except Exception as e:
-        utils.logger.error(f"Error while loading module: {e}")
-        await ctx.reply("Module failed to load. Check console for info.")
+#@slash.slash(
+#    name='load',
+#    description='Loads the specified module to the bot',
+#    options=[
+#        create_option(name='module', description='Which module do you want to load? (only in cogs folder)', option_type=3, required=True)
+#    ]
+#)
+#async def load(ctx:SlashContext, module:str):
+#    if ctx.author.id != 738290097170153472: return ctx.send("Sorry, but this command is only for my developer's use.", hidden=True)
+#    try:
+#        utils.logger.info(f"Attempting to load module \"{module}\".")
+#        client.load_extension(module)
+#        utils.logger.info("Success loading module!")
+#        await ctx.reply("Module loaded!")
+#    except Exception as e:
+#        utils.logger.error(f"Error while loading module: {e}")
+#        await ctx.reply("Module failed to load. Check console for info.")
 
-@slash.slash(
-    name='unload',
-    description='Removes the specified module from the bot',
-    options=[
-        create_option(name='module', description='Which module do you want to unload? (only in cogs folder)', option_type=3, required=True)
-    ]
-)
-async def unload(ctx:SlashContext, module:str):
-    if ctx.author.id != 738290097170153472: return ctx.send("Sorry, but this command is only for my developer's use.", hidden=True)
-    try:
-        utils.logger.info(f"Attempting to unload module \"{module}\".")
-        client.unload_extension(module)
-        utils.logger.info("Success removing module!")
-        await ctx.reply("Module unloaded!")
-    except Exception as e:
-        utils.logger.error(f"Error while unloading module: {e}")
-        await ctx.reply("Module failed to unload. Check console for info.")
+#@slash.slash(
+#    name='unload',
+#    description='Removes the specified module from the bot',
+#    options=[
+#        create_option(name='module', description='Which module do you want to unload? (only in cogs folder)', option_type=3, required=True)
+#    ]
+#)
+#async def unload(ctx:SlashContext, module:str):
+#    if ctx.author.id != 738290097170153472: return ctx.send("Sorry, but this command is only for my developer's use.", hidden=True)
+#    try:
+#        utils.logger.info(f"Attempting to unload module \"{module}\".")
+#        client.unload_extension(module)
+#        utils.logger.info("Success removing module!")
+#        await ctx.reply("Module unloaded!")
+#    except Exception as e:
+#        utils.logger.error(f"Error while unloading module: {e}")
+#        await ctx.reply("Module failed to unload. Check console for info.")
 
 @slash.slash(name='balance', description='Shows your own or another user\'s balance.', options=[create_option(name='user', description='Which user?', option_type=6, required=False)])
 async def balance(ctx:SlashContext, user=None):


### PR DESCRIPTION
Cog support is being removed as discord.py doesn't support slash commands in cogs. I might add it back if I can get Py-cord to work correctly with the client.