### PR TITLE
Send help command list embeds to user DMs instead of in server channel

### DIFF
--- a/main.py
+++ b/main.py
@@ -226,7 +226,9 @@ async def help(ctx: ApplicationContext, command:str=None):
         for x in commandsdb: 
             if commandsdb[x]["type"] != "DevTools": r += f"`/{x}`\n"
         localembed = discord.Embed(title="Isobot Command Help", description=f"**Bot Commands:**\n{r}", color = color)
-        await ctx.respond(embed=localembed)
+        user = client.get_user(ctx.author.id)
+        await user.send(embed=localembed)
+        await ctx.respond("Check your direct messages.", hidden=True)
 
 @client.slash_command(
     name='balance', 


### PR DESCRIPTION
Reduces the amount of unnecessary bot text in a server channel. Also, reactions can most probably be used with plain message contexts (like the new help embed message).