### PR TITLE
Fix issue where help command does not send embed in user DMs and returns no response error

### DIFF
--- a/main.py
+++ b/main.py
@@ -226,7 +226,7 @@ async def help(ctx: ApplicationContext, command:str=None):
         for x in commandsdb: 
             if commandsdb[x]["type"] != "DevTools": r += f"`/{x}`\n"
         localembed = discord.Embed(title="Isobot Command Help", description=f"**Bot Commands:**\n{r}", color = color)
-        user = client.get_user(ctx.author.id)
+        user = client.fetch_user(ctx.author.id)
         await user.send(embed=localembed)
         await ctx.respond("Check your direct messages.", ephemeral=True)
 

--- a/main.py
+++ b/main.py
@@ -228,7 +228,7 @@ async def help(ctx: ApplicationContext, command:str=None):
         localembed = discord.Embed(title="Isobot Command Help", description=f"**Bot Commands:**\n{r}", color = color)
         user = client.get_user(ctx.author.id)
         await user.send(embed=localembed)
-        await ctx.respond("Check your direct messages.", hidden=True)
+        await ctx.respond("Check your direct messages.", ephemeral=True)
 
 @client.slash_command(
     name='balance', 


### PR DESCRIPTION
This patch changes the retrieval of user context data from cache to a direct API request while sending a DM response, as using cache is more likely to fail rather than force-fetching new data. 
Also the `hide` parameter has been changed to `ephemeral` parameter for hidden messages in the `respond()` and `send()` commands. (in Pycord)