### PR TITLE
Add runtime mode option for switching between local and replit modes

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -32,3 +32,7 @@ def get_public_key():
     """Returns the bot's public key in `runtimeconfig.json`, if it exists."""
     if config["public_key"]: return config["public_key"]
     else: return "Public key has not been set."
+
+def get_mode() -> bool:
+    """Returns a boolean of the current runtime mode.\n\nReturns `True` if replit mode is active, returns `False` if replit mode is inactive."""
+    return config["replit"]

--- a/api/runtimeconfig.json
+++ b/api/runtimeconfig.json
@@ -2,5 +2,6 @@
     "token": "",
     "secret": "",
     "public_key": "",
-    "runtime_options": []
+    "runtime_options": [],
+	"replit": true
 }

--- a/main.py
+++ b/main.py
@@ -482,7 +482,12 @@ for x in active_cogs:
 if cog_errors == 0: print(f"[main/Cogs] {colors.green}All cogs successfully loaded.{colors.end}")
 else: print(f"[main/Cogs] {colors.yellow}{cog_errors}/{len(active_cogs)} cogs failed to load.{colors.end}")
 print("--------------------")
-client.run(api.auth.get_token())
+if api.auth.get_mode(): 
+    print(f"[main/CLIENT] Starting client in {colors.cyan}Replit mode{colors.end}...")
+    client.run(os.getenv("TOKEN"))
+else:
+    print(f"[main/CLIENT] Starting client in {colors.orange}local mode{colors.end}...") 
+    client.run(api.auth.get_token())
 
 
 


### PR DESCRIPTION
### Runtime mode configuration
You can switch from local to replit or vice-versa in the runtime configuration by modifying the value in the `replit` key in the runtimeconfig.json file. 

`true` enables replit mode (storing bot token in replit environment variable) and `false` uses the token provided in the runtimeconfig.json file. The environment variable name for the bot token is `TOKEN`.
If replit runtime mode is enabled, then the `token` value in runtimeconfig.json can be left empty. But if it is disabled, a token will be needed in the configuration file.

Automatic detection may come sometime in the future.