### PR TITLE
Add exception type display in embed on failing of any cog command

### DIFF
--- a/main.py
+++ b/main.py
@@ -276,7 +276,14 @@ async def load(ctx: ApplicationContext, cog: str):
     try:
         client.load_extension(f"cogs.{cog}")
         await ctx.respond(embed=discord.Embed(description=f"{cog} cog successfully loaded.", color=discord.Color.green()))
-    except Exception as e: await ctx.respond(embed=discord.Embed(description=f"{cog} failed to load: {e}", color=discord.Color.red()))
+    except Exception as e:
+        await ctx.respond(
+            embed=discord.Embed(
+                title=f"{cog} failed to load",
+                description=f"```{type(e).__name__}: {e}```",
+                color=discord.Color.red()
+            )
+        )
 
 @cogs.command(
     name="disable",
@@ -288,7 +295,14 @@ async def disable(ctx: ApplicationContext, cog: str):
     try:
         client.unload_extension(f"cogs.{cog}")
         await ctx.respond(embed=discord.Embed(description=f"{cog} cog successfully disabled.", color=discord.Color.green()))
-    except: await ctx.respond(embed=discord.Embed(description=f"{cog} cog not found."), color=discord.Color.red())
+    except Exception as e:
+        await ctx.respond(
+            embed=discord.Embed(
+                title=f"{cog} failed to disable",
+                description=f"```{type(e).__name__}: {e}```",
+                color=discord.Color.red()
+            )
+        )
 
 @cogs.command(
     name="reload",
@@ -300,7 +314,14 @@ async def reload(ctx: ApplicationContext, cog: str):
     try:
         client.reload_extension(f"cogs.{cog}")
         await ctx.respond(embed=discord.Embed(description=f"{cog} cog successfully reloaded.", color=discord.Color.green()))
-    except: await ctx.respond(embed=discord.Embed(description=f"{cog} cog not found.", color=discord.Color.red()))
+    except Exception as e:
+        await ctx.respond(
+            embed=discord.Embed(
+                title=f"{cog} failed to reload",
+                description=f"```{type(e).__name__}: {e}```",
+                color=discord.Color.red()
+            )
+        )
 
 # Initialization
 active_cogs = [


### PR DESCRIPTION
This will help give more insights into why a cog failed to load, rather than just checking the developer console.