### PR TITLE
Add leaderboard command for viewing ranking for user net worth

### DIFF
--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -711,6 +711,35 @@ class Economy(commands.Cog):
     async def treasury(self, ctx: ApplicationContext):
         localembed = discord.Embed(description="There are currently {currency['treasury']} coins in the isobot treasury.")
         await ctx.respond(embed=localembed)
+    
+    @commands.slash_command(
+        name="leaderboard_nw", 
+        description="View the global leaderboard for net worth."
+    )
+    async def leaderboard_nw(self, ctx: ApplicationContext):
+        nw_dict = dict()
+        for person in currency:
+            nw_dict[str(person)] = int(currency["wallet"][str(person)]) + int(currency["bank"][str(person)])
+        undicted_leaderboard = sorted(nw_dict.items(), key=lambda x:x[1], reverse=True)
+        dicted_leaderboard = dict(undicted_leaderboard)
+        parsed_output = str()
+        y = 1
+        for i in dicted_leaderboard:
+            if y < 5:
+                try:
+                    if nw_dict[i] != 0:
+                        user_context = await commands.fetch_user(i)
+                        if not user_context.bot:
+                            print(i, nw_dict[i])
+                            if y == 1: yf = ":first_place:"
+                            elif y == 2: yf = ":second_place:"
+                            elif y == 3: yf = ":third_place:"
+                            else: yf = f"#{y}"
+                            parsed_output += f"{yf} **{user_context.name}:** {nw_dict[i]} coins\n"
+                            y += 1
+                except discord.errors.NotFound: continue
+        localembed = discord.Embed(title="Global net worth leaderboard", description=parsed_output, color=color)
+        await ctx.respond(embed=localembed)
 
 # Initialization
 def setup(bot):

--- a/cogs/levelling.py
+++ b/cogs/levelling.py
@@ -70,10 +70,10 @@ class Levelling(commands.Cog):
         except KeyError: return await ctx.respond("That user isn't indexed yet.", ephemeral=True)
 
     @commands.slash_command(
-        name="leaderboard", 
+        name="leaderboard_levels", 
         description="View the global leaderboard for user levelling ranks."
     )
-    async def leaderboard(self, ctx: ApplicationContext):
+    async def leaderboard_levels(self, ctx: ApplicationContext):
         levels_dict = dict()
         for person in levels:
             levels_dict[str(person)] = levels[str(person)]["level"]

--- a/config/commands.json
+++ b/config/commands.json
@@ -638,9 +638,8 @@
 	"usable_by": "everyone",
 	"disabled": false,
 	"bugged": false
-  }
-  ,
-  "leaderboard": {
+  },
+  "leaderboard_levels": {
 	"name": "Levelling Leaderboard",
 	"description": "See the global leaderboard for user levels.",
 	"type": "levelling",

--- a/config/commands.json
+++ b/config/commands.json
@@ -648,5 +648,15 @@
 	"usable_by": "everyone",
 	"disabled": false,
 	"bugged": false
+  },
+  "leaderboard_nw": {
+	"name": "Net Worth Leaderboard",
+	"description": "See the global leaderboard for user net worth.",
+	"type": "economy",
+	"cooldown": null,
+	"args": null,
+	"usable_by": "everyone",
+	"disabled": false,
+	"bugged": false
   }
 }

--- a/main.py
+++ b/main.py
@@ -75,15 +75,15 @@ currency_unused = framework.isobot.currency.CurrencyAPI(f'{wdir}/database/curren
 # isobank = framework.isobank.manager.IsoBankManager(f"{wdir}/database/isobank/accounts.json", f"{wdir}/database/isobank/auth.json")
 isobankauth = framework.isobank.authorize.IsobankAuth(f"{wdir}/database/isobank/auth.json", f"{wdir}/database/isobank/accounts.json")
 
-#Theme Loader
-with open("themes/halloween.theme.json", 'r', encoding="utf-8") as f:
-    theme = json.load(f)
-    try:
-        color_loaded = theme["theme"]["embed_color"]
-        color = int(color_loaded, 16)
-    except KeyError:
-        print(f"{colors.red}The theme file being loaded might be broken. Rolling back to default configuration...{colors.end}")
-        color = discord.Color.random()
+# Theme Loader
+#with open("themes/halloween.theme.json", 'r', encoding="utf-8") as f:
+#    theme = json.load(f)
+#    try:
+#        color_loaded = theme["theme"]["embed_color"]
+#        color = int(color_loaded, 16)
+#    except KeyError:
+#        print(f"{colors.red}The theme file being loaded might be broken. Rolling back to default configuration...{colors.end}")
+#        color = discord.Color.random()
 
 #Events
 @client.event


### PR DESCRIPTION
### Net Worth Leaderboard
This command lets you see the global ranking of all the users based on their net worth. This command is copied from the levelling leaderboard command, but some adjustments have been made to it to work with user net worth.

Originally, I would have set the leaderboard to display 10 users' rankings, but I instead set it to 5, as fetching more users' data from the api could hang the bot and the command would have expired by then.