### PR TITLE
Add OpenAI ChatGPT integration with `/chatgpt` command

### DIFF
--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -136,7 +136,7 @@ class Utils(commands.Cog):
             _reply = _chat.choices[0].message.content
             chatgpt_conversation[str(ctx.author.id)].append({"role": "assistant", "content": _reply})
         except openai.error.RateLimitError: return await ctx.respond("The OpenAI API is currently being rate-limited. Try again after some time.", ephemeral=True)
-        except openai.error.ServiceUnavailableError: return await ctx.respond("The ChatGPT service is currently down.\nTry again after some time, or check it's status at https://status.openai.com", ephemeral=True)
+        except openai.error.ServiceUnavailableError: return await ctx.respond("The ChatGPT service is currently unavailable.\nTry again after some time, or check it's status at https://status.openai.com", ephemeral=True)
         except openai.error.APIError: return await ctx.respond("ChatGPT encountered an internal error. Please try again.", ephemeral=True)
         except openai.error.Timeout: return await ctx.respond("Your request timed out. Please try again, or wait for a while.", ephemeral=True)
         localembed = discord.Embed(description=f"{_reply}", color=discord.Color.random())

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -135,7 +135,7 @@ class Utils(commands.Cog):
         _reply = _chat.choices[0].message.content
         chatgpt_conversation[str(ctx.author.id)].append({"role": "assistant", "content": _reply})
         localembed = discord.Embed(description=f"{_reply}", color=discord.Color.random())
-        localembed.set_author(name="ChatGPT", icon_url="https://static.vecteezy.com/system/resources/previews/021/608/790/original/chatgpt-logo-chat-gpt-icon-on-black-background-free-vector.jpg")
+        localembed.set_author(name="ChatGPT", icon_url="https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/ChatGPT_logo.svg/1200px-ChatGPT_logo.svg.png")
         localembed.set_footer(text="Powered by OpenAI")
         await ctx.respond(embed=localembed)
 

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -131,7 +131,7 @@ class Utils(commands.Cog):
         chatgpt_conversation.append({"role": "user", "content": message})
         _chat = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=chatgpt_conversation)
         _reply = _chat.choices[0].message.content
-        chatgpt_conversation.append({"role": "assistant", "content": reply})
+        chatgpt_conversation.append({"role": "assistant", "content": _reply})
         localembed = discord.Embed(description=f"```\n{_reply}\n```", color=discord.Color.random())
         localembed.set_author(name="ChatGPT", icon_url="https://static.vecteezy.com/system/resources/previews/021/608/790/original/chatgpt-logo-chat-gpt-icon-on-black-background-free-vector.jpg")
         localembed.set_footer(text="Powered by OpenAI")

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -16,7 +16,7 @@ from cogs.afk import get_presence
 # Variables
 color = discord.Color.random()
 openai.api_key = os.getenv("chatgpt_API_KEY")
-chatgpt_conversation = list()
+chatgpt_conversation = dict()
 
 # Commands
 class Utils(commands.Cog):

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -128,6 +128,7 @@ class Utils(commands.Cog):
     @option(name="message", description="What do you want to send to ChatGPT?", type=str)
     @commands.cooldown(1, 1, commands.BucketType.user)
     async def chatgpt(self, ctx: ApplicationContext, message: str):
+        await ctx.defer()
         chatgpt_conversation.append({"role": "user", "content": message})
         _chat = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=chatgpt_conversation)
         _reply = _chat.choices[0].message.content

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -16,7 +16,7 @@ from cogs.afk import get_presence
 # Variables
 color = discord.Color.random()
 openai.api_key = os.getenv("chatgpt_API_KEY")
-chatgpt_conversation = [{"role": "system", "content": "You are a intelligent assistant."}]
+chatgpt_conversation = list()
 
 # Commands
 class Utils(commands.Cog):
@@ -128,11 +128,12 @@ class Utils(commands.Cog):
     @option(name="message", description="What do you want to send to ChatGPT?", type=str)
     @commands.cooldown(1, 1, commands.BucketType.user)
     async def chatgpt(self, ctx: ApplicationContext, message: str):
+        if str(ctx.author.id) not in chatgpt_conversation: chatgpt_conversation[str(ctx.author.id)] = [{"role": "system", "content": "You are a intelligent assistant."}]
         await ctx.defer()
-        chatgpt_conversation.append({"role": "user", "content": message})
-        _chat = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=chatgpt_conversation)
+        chatgpt_conversation[str(ctx.author.id)].append({"role": "user", "content": message})
+        _chat = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=chatgpt_conversation[str(ctx.author.id)])
         _reply = _chat.choices[0].message.content
-        chatgpt_conversation.append({"role": "assistant", "content": _reply})
+        chatgpt_conversation[str(ctx.author.id)].append({"role": "assistant", "content": _reply})
         localembed = discord.Embed(description=f"{_reply}", color=discord.Color.random())
         localembed.set_author(name="ChatGPT", icon_url="https://static.vecteezy.com/system/resources/previews/021/608/790/original/chatgpt-logo-chat-gpt-icon-on-black-background-free-vector.jpg")
         localembed.set_footer(text="Powered by OpenAI")

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -132,7 +132,7 @@ class Utils(commands.Cog):
         _chat = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=chatgpt_conversation)
         _reply = _chat.choices[0].message.content
         chatgpt_conversation.append({"role": "assistant", "content": _reply})
-        localembed = discord.Embed(description=f"```\n{_reply}\n```", color=discord.Color.random())
+        localembed = discord.Embed(description=f"{_reply}", color=discord.Color.random())
         localembed.set_author(name="ChatGPT", icon_url="https://static.vecteezy.com/system/resources/previews/021/608/790/original/chatgpt-logo-chat-gpt-icon-on-black-background-free-vector.jpg")
         localembed.set_footer(text="Powered by OpenAI")
         await ctx.respond(embed=localembed)

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -125,6 +125,7 @@ class Utils(commands.Cog):
         description="Talk to ChatGPT and get a response back."
     )
     @option(name="message", description="What do you want to send to ChatGPT?", type=str)
+    @commands.cooldown(1, 1, commands.BucketType.user)
     async def chatgpt(ctx: ApplicationContext, message: str):
         response = openai.generate_response(message)
         localembed = discord.Embed(description=f"```\n{response}\n```", color=discord.Color.random())

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -8,12 +8,14 @@ import math
 import framework.isobot.embedengine
 from discord import option, ApplicationContext
 from discord.ext import commands
+from chatgpt import ChatGPT
 from cogs.economy import get_wallet, get_bank, get_user_networth, get_user_count
 from cogs.levelling import get_level, get_xp
 from cogs.afk import get_presence
 
 # Variables
 color = discord.Color.random()
+openai = ChatGPT()
 
 # Commands
 class Utils(commands.Cog):
@@ -116,6 +118,18 @@ class Utils(commands.Cog):
         localembed.add_field(name="Uptime History", value="[here](https://stats.uptimerobot.com/PlKOmI0Aw8)")
         localembed.add_field(name="Release Notes", value="[latest](https://github.com/PyBotDevs/isobot/releases/latest)")
         localembed.set_footer(text=f"Requested by {ctx.author.name}", icon_url=ctx.author.avatar_url)
+        await ctx.respond(embed=localembed)
+    
+    @commands.slash_command(
+        name="chatgpt",
+        description="Talk to ChatGPT and get a response back."
+    )
+    @option(name="message", description="What do you want to send to ChatGPT?", type=str)
+    async def chatgpt(ctx: ApplicationContext, message: str):
+        response = openai.generate_response(message)
+        localembed = discord.Embed(description=f"```\n{response}\n```", color=discord.Color.random())
+        localembed.set_author(name="ChatGPT", icon_url="https://static.vecteezy.com/system/resources/previews/021/608/790/original/chatgpt-logo-chat-gpt-icon-on-black-background-free-vector.jpg")
+        localembed.set_footer(text="Powered by OpenAI")
         await ctx.respond(embed=localembed)
 
 # Cog Initialization

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -127,7 +127,7 @@ class Utils(commands.Cog):
     )
     @option(name="message", description="What do you want to send to ChatGPT?", type=str)
     @commands.cooldown(1, 1, commands.BucketType.user)
-    async def chatgpt(ctx: ApplicationContext, message: str):
+    async def chatgpt(self, ctx: ApplicationContext, message: str):
         chatgpt_conversation.append({"role": "user", "content": message})
         _chat = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=chatgpt_conversation)
         _reply = _chat.choices[0].message.content

--- a/config/commands.json
+++ b/config/commands.json
@@ -688,5 +688,15 @@
 	"usable_by": "everyone",
 	"disabled": false,
 	"bugged": false
+  },
+  "chatgpt": {
+	"name": "ChatGPT",
+	"description": "Talk to ChatGPT and get a response back.",
+	"type": "general utilities",
+	"cooldown": 1,
+	"args": ["message"],
+	"usable_by": "everyone",
+	"disabled": false,
+	"bugged": false
   }
 }


### PR DESCRIPTION
### ChatGPT command
This new command lets users chat with OpenAI's ChatGPT through isobot, mitigating the need to open the ChatGPT website/app, or having to create an OpenAI account.
All active ChatGPT conversations are linked to your Discord user id, however conversations are not permanently stored. Once the bot restarts, all conversation data is anonymized and then deleted from cache.

Example: (message: "how to use print output in c++")
![Screenshot_20230526_204009](https://github.com/PyBotDevs/isobot/assets/72265661/590ddbc3-f895-4c4a-bb8c-52e2064fbe75)


This command and the use of the ChatGPT AI modal are in accordance with OpenAI's code of conduct and are operated securely.

