### PR TITLE
Add `/generate_image` command to let users generate images using DALL-E modal

### DIFF
--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -153,15 +153,13 @@ class Utils(commands.Cog):
     async def generate_image(self, ctx: ApplicationContext, prompt: str):
         await ctx.defer()
         try:
-            response = openai.Completion.create(
-                engine="davinci",
+            response = openai.Image.create(
                 prompt=prompt,
-                max_tokens=1024,
                 n=1,
-                stop=None,
-                temperature=0.5,
+                size="512x512"
             )
-            generated_image_url = response.choices[0].text
+            generated_image_url = response['data'][0]['url']
+            print(generated_image_url)
         except openai.error.RateLimitError: return await ctx.respond("The OpenAI API is currently being rate-limited. Try again after some time.", ephemeral=True)
         except openai.error.ServiceUnavailableError: return await ctx.respond("The ChatGPT service is currently unavailable.\nTry again after some time, or check it's status at https://status.openai.com", ephemeral=True)
         except openai.error.APIError: return await ctx.respond("ChatGPT encountered an internal error. Please try again.", ephemeral=True)

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -143,6 +143,34 @@ class Utils(commands.Cog):
         localembed.set_author(name="ChatGPT", icon_url="https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/ChatGPT_logo.svg/1200px-ChatGPT_logo.svg.png")
         localembed.set_footer(text="Powered by OpenAI")
         await ctx.respond(embed=localembed)
+    
+    @commands.slash_command(
+        name="generate_image",
+        description="Generate an image of your choice using the DALL-E modal."
+    )
+    @option(name="prompt", description="What image do you want the bot to generate?", type=str)
+    @commands.cooldown(1, 10, commands.BucketType.user)
+    async def generate_image(self, ctx: ApplicationContext, prompt: str):
+        await ctx.defer()
+        try:
+            response = openai.Completion.create(
+                engine="davinci",
+                prompt=prompt,
+                max_tokens=1024,
+                n=1,
+                stop=None,
+                temperature=0.5,
+            )
+            generated_image_url = response.choices[0].text
+        except openai.error.RateLimitError: return await ctx.respond("The OpenAI API is currently being rate-limited. Try again after some time.", ephemeral=True)
+        except openai.error.ServiceUnavailableError: return await ctx.respond("The ChatGPT service is currently unavailable.\nTry again after some time, or check it's status at https://status.openai.com", ephemeral=True)
+        except openai.error.APIError: return await ctx.respond("ChatGPT encountered an internal error. Please try again.", ephemeral=True)
+        except openai.error.Timeout: return await ctx.respond("Your request timed out. Please try again, or wait for a while.", ephemeral=True)
+        localembed = discord.Embed(title="Here's an image generated using your prompt.", color=discord.Color.random())
+        localembed.set_image(url=generated_image_url)
+        localembed.set_author(name="DALL-E", icon_url="https://upload.wikimedia.org/wikipedia/commons/thumb/0/04/ChatGPT_logo.svg/1200px-ChatGPT_logo.svg.png")
+        localembed.set_footer(text="Powered by OpenAI")
+        await ctx.respond(embed=localembed)
 
 # Cog Initialization
 def setup(bot): bot.add_cog(Utils(bot))

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -159,7 +159,6 @@ class Utils(commands.Cog):
                 size="512x512"
             )
             generated_image_url = response['data'][0]['url']
-            print(generated_image_url)
         except openai.error.RateLimitError: return await ctx.respond("The OpenAI API is currently being rate-limited. Try again after some time.", ephemeral=True)
         except openai.error.ServiceUnavailableError: return await ctx.respond("The ChatGPT service is currently unavailable.\nTry again after some time, or check it's status at https://status.openai.com", ephemeral=True)
         except openai.error.APIError: return await ctx.respond("ChatGPT encountered an internal error. Please try again.", ephemeral=True)

--- a/config/commands.json
+++ b/config/commands.json
@@ -698,5 +698,15 @@
 	"usable_by": "everyone",
 	"disabled": false,
 	"bugged": false
+  },
+  "generate_image": {
+	"name": "Image Generation",
+	"description": "Generate an image of your choice using the DALL-E modal.",
+	"type": "general utilities",
+	"cooldown": 10,
+	"args": ["prompt"],
+	"usable_by": "everyone",
+	"disabled": false,
+	"bugged": false
   }
 }


### PR DESCRIPTION
### DALL-E image generation
This command lets users generate any image they want through isobot, with the help of DALL-E 2 and the OpenAI API.

No request or image data is stored on our servers and this command is made in compliance with OpenAI's code of conduct and terms & conditions.

Example of `/generate_image` (prompt: "an armchair in the shape of an avocado"):
![Screenshot_20230528_230636](https://github.com/PyBotDevs/isobot/assets/72265661/1910c36f-563b-4c41-8df5-c1d269644d55)
