### PR TITLE
Fix all leaderboard commands from hanging while fetching user data from API

### DIFF
--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -717,6 +717,7 @@ class Economy(commands.Cog):
         description="View the global leaderboard for net worth."
     )
     async def leaderboard_nw(self, ctx: ApplicationContext):
+        await ctx.defer()
         nw_dict = dict()
         for person in currency:
             nw_dict[str(person)] = int(currency["wallet"][str(person)]) + int(currency["bank"][str(person)])

--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -726,7 +726,7 @@ class Economy(commands.Cog):
         parsed_output = str()
         y = 1
         for i in dicted_leaderboard:
-            if y < 5:
+            if y < 10:
                 try:
                     if nw_dict[i] != 0:
                         user_context = await commands.fetch_user(i)

--- a/cogs/levelling.py
+++ b/cogs/levelling.py
@@ -74,6 +74,7 @@ class Levelling(commands.Cog):
         description="View the global leaderboard for user levelling ranks."
     )
     async def leaderboard_levels(self, ctx: ApplicationContext):
+        await ctx.defer()
         levels_dict = dict()
         for person in levels:
             levels_dict[str(person)] = levels[str(person)]["level"]


### PR DESCRIPTION
### Leaderboard patch (derived from issue #279)
There has been an issue reported where the leaderboard commands (both net-worth and levelling) tend to hang the bot while fetching user data from the Discord API, resulting in the command invokation expiring and leading to such a message.

![Screenshot_20230529_000241](https://github.com/PyBotDevs/isobot/assets/72265661/9cba05fb-212c-4d6e-a933-414bc2cb7e03)

However I discovered something known as `await ctx.defer()`, which lets you reserve outgoing commands interactions by sending a pre-response before later editing it and sending the actual response. (the leaderboard)

I realised it's a very simple and easy-to-implement fix and I now wonder why I didn't think of it before :thinking: 