### PR TITLE
Disable IsoBank auth module from loading on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -73,7 +73,7 @@ class plugins:
 colors = framework.isobot.colors.Colors()
 currency_unused = framework.isobot.currency.CurrencyAPI(f"{wdir}/database/currency.json", f"{wdir}/logs/currency.log")  # Initialize part of the framework (Currency)
 # isobank = framework.isobank.manager.IsoBankManager(f"{wdir}/database/isobank/accounts.json", f"{wdir}/database/isobank/auth.json")
-isobankauth = framework.isobank.authorize.IsobankAuth(f"{wdir}/database/isobank/auth.json", f"{wdir}/database/isobank/accounts.json")
+# isobankauth = framework.isobank.authorize.IsobankAuth(f"{wdir}/database/isobank/auth.json", f"{wdir}/database/isobank/accounts.json")
 
 # Theme Loader
 #with open("themes/halloween.theme.json", 'r', encoding="utf-8") as f:


### PR DESCRIPTION
Should prevent excess memory usage by a *little bit*