### PR TITLE
Remove `/sync` DevTools command

### DIFF
--- a/config/commands.json
+++ b/config/commands.json
@@ -89,16 +89,6 @@
       "disabled": true,
       "bugged": false
   },
-  "sync": {
-      "name": "Sync Databases",
-      "description": "Re-caches and reloads all of the bot databases on memory.",
-      "type": "DevTools",
-      "cooldown": null,
-      "args": null,
-      "usable_by": "the developer",
-      "disabled": false,
-      "bugged": false
-  },
   "modify_balance": {
       "name": "Modify Balance",
       "description": "Modify a user's wallet balance.",

--- a/main.py
+++ b/main.py
@@ -199,21 +199,6 @@ async def help(ctx: ApplicationContext, command: str = None):
         await ctx.author.send(embed=localembed)
         await ctx.respond("Check your direct messages.", ephemeral=True)
 
-# DevTools commands
-@client.slash_command(
-    name='sync',
-    description='Syncs all of the local databases with their latest version'
-)
-async def sync(ctx: ApplicationContext):
-    if ctx.author.id != 738290097170153472: return await ctx.respond('Sorry, this command is only for my developer\'s use.')
-    try:
-        with open('database/items.json', 'r') as f: items = json.load(f)
-        with open('config/shop.json', 'r') as f: shopitem = json.load(f)
-        await ctx.respond('Databases resynced.', ephemeral=True)
-    except Exception as e:
-        print(e)
-        await ctx.respond('An error occured while resyncing. Check console.', ephemeral=True)
-
 # Cog Commands (these cannot be moved into a cog)
 cogs = client.create_group("cog", "Commands for working with isobot cogs.")
 


### PR DESCRIPTION
### Removal of `/sync` command
This command was previously being used when the databases were managed all at `main.py`, instead of in separate bot cogs.
Now, since all the databases are automatically managed by these bot cogs, there is no more use for the `/sync` command, which means its time to call it off from isobot.