### PR TITLE
Add custom image output resolution for `/generate_image` command

### DIFF
--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -157,8 +157,8 @@ class Utils(commands.Cog):
         max_index: int = 0
         for index in parsed_resolution: max_index += 1
         if max_index < 2 or max_index > 2: return await ctx.respond("Your resolution format is malformed. Please check it and try again.", ephemeral=True)
-        res_width = parsed_resolution[0]
-        res_height = parsed_resolution[1]
+        res_width = int(parsed_resolution[0])
+        res_height = int(parsed_resolution[1])
         if res_width < 256 or res_height < 256: return await ctx.respond("Your custom resolution needs to be at least 256p or higher.", ephermeral=True)
         if res_width > 1024 or res_height > 1024: return await ctx.respond("Your image output resolution cannot be higher than 1024p.", ephemeral=True)
         await ctx.defer()

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -159,8 +159,8 @@ class Utils(commands.Cog):
         if max_index < 2 or max_index > 2: return await ctx.respond("Your resolution format is malformed. Please check it and try again.", ephemeral=True)
         res_width = parsed_resolution[0]
         res_height = parsed_resolution[1]
-        if res_width < 1 or res_height < 1: return await ctx.respond("Your resolution's width and height values need to be at least 1 pixel or higher.", ephermeral=True)
-        if res_width > 3840 or res_height > 2160: return await ctx.respond("Your image output resolution cannot be higher than 4K UHD. (3840 × 2160)", ephmeral=True)
+        if res_width < 256 or res_height < 256: return await ctx.respond("Your custom resolution needs to be at least 256p or higher.", ephermeral=True)
+        if res_width > 1024 or res_height > 1024: return await ctx.respond("Your image output resolution cannot be higher than 1024p.", ephmeral=True)
         await ctx.defer()
         try:
             response = openai.Image.create(

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -150,14 +150,15 @@ class Utils(commands.Cog):
         description="Generate an image of your choice using the DALL-E modal."
     )
     @option(name="prompt", description="What image do you want the bot to generate?", type=str)
+    @option(name="resolution", description="Set a custom resolution for your generated image", type=str, default="512x512")
     @commands.cooldown(1, 10, commands.BucketType.user)
-    async def generate_image(self, ctx: ApplicationContext, prompt: str):
+    async def generate_image(self, ctx: ApplicationContext, prompt: str, resolution: str = "512x512"):
         await ctx.defer()
         try:
             response = openai.Image.create(
                 prompt=prompt,
                 n=1,
-                size="512x512"
+                size=resolution
             )
             generated_image_url = response['data'][0]['url']
         except openai.error.RateLimitError: return await ctx.respond("The OpenAI API is currently being rate-limited. Try again after some time.", ephemeral=True)

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -170,8 +170,8 @@ class Utils(commands.Cog):
             )
             generated_image_url = response['data'][0]['url']
         except openai.error.RateLimitError: return await ctx.respond("The OpenAI API is currently being rate-limited. Try again after some time.", ephemeral=True)
-        except openai.error.ServiceUnavailableError: return await ctx.respond("The ChatGPT service is currently unavailable.\nTry again after some time, or check it's status at https://status.openai.com", ephemeral=True)
-        except openai.error.APIError: return await ctx.respond("ChatGPT encountered an internal error. Please try again.", ephemeral=True)
+        except openai.error.ServiceUnavailableError: return await ctx.respond("The OpenAI service is currently unavailable.\nTry again after some time, or check it's status at https://status.openai.com", ephemeral=True)
+        except openai.error.APIError: return await ctx.respond("DALL-E encountered an internal error. Please try again.", ephemeral=True)
         except openai.error.Timeout: return await ctx.respond("Your request timed out. Please try again, or wait for a while.", ephemeral=True)
         localembed = discord.Embed(title="Here's an image generated using your prompt.", color=discord.Color.random())
         localembed.set_image(url=generated_image_url)

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -150,9 +150,17 @@ class Utils(commands.Cog):
         description="Generate an image of your choice using the DALL-E modal."
     )
     @option(name="prompt", description="What image do you want the bot to generate?", type=str)
-    @option(name="resolution", description="Set a custom resolution for your generated image", type=str, default="512x512")
+    @option(name="resolution", description="Set a custom resolution for your generated image (format: {width}x{height})", type=str, default="512x512")
     @commands.cooldown(1, 10, commands.BucketType.user)
     async def generate_image(self, ctx: ApplicationContext, prompt: str, resolution: str = "512x512"):
+        parsed_resolution: list = resolution.split("x")
+        max_index: int = 0
+        for index in parsed_resolution: max_index += 1
+        if max_index < 2 or max_index > 2: return await ctx.respond("Your resolution format is malformed. Please check it and try again.", ephemeral=True)
+        res_width = parsed_resolution[0]
+        res_height = parsed_resolution[1]
+        if res_width < 1 or res_height < 1: return await ctx.respond("Your resolution's width and height values need to be at least 1 pixel or higher.", ephermeral=True)
+        if res_width > 3840 or res_height > 2160: return await ctx.respond("Your image output resolution cannot be higher than 4K UHD. (3840 × 2160)", ephmeral=True)
         await ctx.defer()
         try:
             response = openai.Image.create(

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -160,7 +160,7 @@ class Utils(commands.Cog):
         res_width = parsed_resolution[0]
         res_height = parsed_resolution[1]
         if res_width < 256 or res_height < 256: return await ctx.respond("Your custom resolution needs to be at least 256p or higher.", ephermeral=True)
-        if res_width > 1024 or res_height > 1024: return await ctx.respond("Your image output resolution cannot be higher than 1024p.", ephmeral=True)
+        if res_width > 1024 or res_height > 1024: return await ctx.respond("Your image output resolution cannot be higher than 1024p.", ephemeral=True)
         await ctx.defer()
         try:
             response = openai.Image.create(

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -150,7 +150,7 @@ class Utils(commands.Cog):
         description="Generate an image of your choice using the DALL-E modal."
     )
     @option(name="prompt", description="What image do you want the bot to generate?", type=str)
-    @option(name="resolution", description="Set a custom resolution for your generated image (format: {width}x{height})", type=str, default="512x512")
+    @option(name="resolution", description="Set a custom resolution for your generated image", type=str, default="512x512", choices=["256x256", "512x512", "1024x1024"])
     @commands.cooldown(1, 10, commands.BucketType.user)
     async def generate_image(self, ctx: ApplicationContext, prompt: str, resolution: str = "512x512"):
         parsed_resolution: list = resolution.split("x")

--- a/config/commands.json
+++ b/config/commands.json
@@ -694,7 +694,7 @@
 	"description": "Generate an image of your choice using the DALL-E modal.",
 	"type": "general utilities",
 	"cooldown": 10,
-	"args": ["prompt"],
+	"args": ["prompt", "resolution (optional)"],
 	"usable_by": "everyone",
 	"disabled": false,
 	"bugged": false


### PR DESCRIPTION
### Custom Image Resolution
This lets users use a custom output resolution for their AI-generated image while executing the `/generate_image` command.

**Resolution argument format:** `{width}x{height}`

For example, if I want an image generated with 512p resolution, then i will use `512x512` in the resolution argument.