### PR TITLE
Remove discrim from username display if user is using new username format

### DIFF
--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -63,7 +63,10 @@ class Utils(commands.Cog):
     @option(name="user", description="Who do you want to know about?", type=discord.User, default=None)
     async def whoami(self, ctx: ApplicationContext, user: discord.User=None):
         if user is None: user = ctx.author
-        username = user
+        discrim = user.name.split("#")
+        username = user.name
+        if discrim[-1] == 0:
+            username = user.name.replace("#0", "")
         displayname = user.display_name
         registered = user.joined_at.strftime("%b %d, %Y, %T")
         pfp = user.avatar


### PR DESCRIPTION
### This change was made in light of the new Discord username system.
The new username system features usernames without the discriminator system. (eg: notsniped#4573 -> notsniped)

Since some users still either have not updated their username, and bot users have not received the update yet, the Discord API will return new usernames's discriminators as `#0`.

To prevent this from reflecting on commands which depend on the full username, this change adds a feature to remove usernames with discrim `#0`.