### PR TITLE
Fix a bug which returns `KeyError` when modifying user level

### DIFF
--- a/framework/isobot/db/levelling.py
+++ b/framework/isobot/db/levelling.py
@@ -45,14 +45,14 @@ class Levelling():
     def add_levels(self, user_id: int, count: int) -> int:
         """Adds a specified amount of levels to the specified user."""
         levels = self.load()
-        levels[str(user_id)]["levels"] += count
+        levels[str(user_id)]["level"] += count
         self.save(levels)
         return 0
 
     def remove_levels(self, user_id: int, count: int) -> int:
         """Removes a specified amount of levels from the specified user."""
         levels = self.load()
-        levels[str(user_id)]["levels"] -= count
+        levels[str(user_id)]["level"] -= count
         self.save(levels)
         return 0
 


### PR DESCRIPTION
### Problem
When the levelling db library attempts to add or remove levels from a user (through framework), it ends up failing and returning a `KeyError` exception.

### Reason
This was because in the levelling db library, the `add_levels()` and `remove_levels()` methods were attempting to modify the `levels` value (non-existant) instead of the `level` value (actual key name).

### Conclusion
This patch aims at resolving this issue and providing a bug-free user experience.