### PR TITLE
Remove overhead caused by indenting databases

### DIFF
--- a/framework/isobot/currency.py
+++ b/framework/isobot/currency.py
@@ -44,7 +44,7 @@ class CurrencyAPI(Colors):
         """Adds balance to the specified user."""
         with open(self.db_path, 'r') as f: currency = json.load(f)
         currency["wallet"][str(user)] += int(amount)
-        with open(self.db_path, 'w+') as f: json.dump(currency, f, indent=4)
+        with open(self.db_path, 'w+') as f: json.dump(currency, f)
         with open(self.log_path, 'a') as f:
             f.write(f'{self.get_time()} framework.isobot.currency User({user}): Added {amount} coins to wallet\n')
             f.close()
@@ -54,7 +54,7 @@ class CurrencyAPI(Colors):
         """Adds balance to the specified user's bank account."""
         with open(self.db_path, 'r') as f: currency = json.load(f)
         currency["bank"][str(user)] += int(amount)
-        with open(self.db_path, 'w+') as f: json.dump(currency, f, indent=4)
+        with open(self.db_path, 'w+') as f: json.dump(currency, f)
         with open(self.log_path, 'a') as f:
             f.write(f'{self.get_time()} framework.isobot.currency User({user}): Added {amount} coins to bank\n')
             f.close()
@@ -64,7 +64,7 @@ class CurrencyAPI(Colors):
         """Removes balance from the specified user."""
         with open(self.db_path, 'r') as f: currency = json.load(f)
         currency["wallet"][str(user)] -= int(amount)
-        with open(self.db_path, 'w+') as f: json.dump(currency, f, indent=4)
+        with open(self.db_path, 'w+') as f: json.dump(currency, f)
         with open(self.log_path, 'a') as f:
             f.write(f'{self.get_time()} framework.isobot.currency User({user}): Removed {amount} coins from wallet\n')
             f.close()
@@ -74,7 +74,7 @@ class CurrencyAPI(Colors):
         """Removes balance from the specified user's bank account."""
         with open(self.db_path, 'r') as f: currency = json.load(f)
         currency["bank"][str(user)] -= int(amount)
-        with open(self.db_path, 'w+') as f: json.dump(currency, f, indent=4)
+        with open(self.db_path, 'w+') as f: json.dump(currency, f)
         with open(self.log_path, 'a') as f:
             f.write(f'{self.get_time()} framework.isobot.currency User({user}): Removed {amount} coins from bank\n')
             f.close()
@@ -85,7 +85,7 @@ class CurrencyAPI(Colors):
         with open(self.db_path, 'r') as f: currency = json.load(f)
         currency["wallet"][str(user)] = 0
         currency["bank"][str(user)] = 0
-        with open(self.db_path, 'w+') as f: json.dump(currency, f, indent=4)
+        with open(self.db_path, 'w+') as f: json.dump(currency, f)
         print(f"[Framework/CurrencyAPI] Currency data for \"{user}\" has been wiped")
         with open(self.log_path, 'a') as f:
             f.write(f'{self.get_time()} framework.isobot.currency User({user}): Wiped all currency data\n')
@@ -97,7 +97,7 @@ class CurrencyAPI(Colors):
         with open(self.db_path, 'r') as f: currency = json.load(f)
         currency["bank"][str(user)] += int(amount)
         currency["wallet"][str(user)] -= int(amount)
-        with open(self.db_path, 'w+') as f: json.dump(currency, f, indent=4)
+        with open(self.db_path, 'w+') as f: json.dump(currency, f)
         print(f"[Framework/CurrencyAPI] Moved {amount} coins to bank. User: {user} [{user}]")
         with open(self.log_path, 'a') as f:
             f.write(f'{self.get_time()} framework.isobot.currency User({user}): Moved {amount} coins from wallet to bank\n')
@@ -109,7 +109,7 @@ class CurrencyAPI(Colors):
         with open(self.db_path, 'r') as f: currency = json.load(f)
         currency["wallet"][str(user)] += int(amount)
         currency["bank"][str(user)] -= int(amount)
-        with open(self.db_path, 'w+') as f: json.dump(currency, f, indent=4)
+        with open(self.db_path, 'w+') as f: json.dump(currency, f)
         print(f"[Framework/CurrencyAPI] Moved {amount} coins to wallet. User: {user} [{user}]")
         with open(self.log_path, 'a') as f:
             f.write(f'{self.get_time()} framework.isobot.currency User({user}): Moved {amount} coins from bank to wallet\n')
@@ -119,7 +119,7 @@ class CurrencyAPI(Colors):
     def treasury_add(self, amount: int) -> int:
         with open(self.db_path, 'r') as f: currency = json.load(f)
         currency["treasury"] += int(amount)
-        with open(self.db_path, 'w+') as f: json.dump(currency, f, indent=4)
+        with open(self.db_path, 'w+') as f: json.dump(currency, f)
         with open(self.log_path, 'a') as f:
             f.write(f'{self.get_time()} framework.isobot.currency Treasury: Added {amount} coins to treasury\n')
             f.close()
@@ -128,7 +128,7 @@ class CurrencyAPI(Colors):
     def treasury_remove(self, amount: int) -> int:
         with open(self.db_path, 'r') as f: currency = json.load(f)
         currency["treasury"] -= int(amount)
-        with open(self.db_path, 'w+') as f: json.dump(currency, f, indent=4)
+        with open(self.db_path, 'w+') as f: json.dump(currency, f)
         with open(self.log_path, 'a') as f:
             f.write(f'{self.get_time()} framework.isobot.currency Treasury: Removed {amount} coins from treasury\n')
             f.close()

--- a/framework/isobot/db/automod.py
+++ b/framework/isobot/db/automod.py
@@ -8,7 +8,7 @@ class Automod():
     """Initializes the Automod database system."""
     def __init__(self):
         print("[framework/db/Automod] Automod db library initialized.")
-    
+
     def load(self) -> dict:
         """Fetches and returns the latest data from the items database."""  
         with open("database/automod.json", 'r', encoding="utf8") as f: db = json.load(f)
@@ -16,7 +16,7 @@ class Automod():
 
     def save(self, data: dict) -> int:
         """Dumps all cached data to your local machine."""
-        with open("database/automod.json", 'w+', encoding="utf8") as f: json.dump(data, f, indent=4)
+        with open("database/automod.json", 'w+', encoding="utf8") as f: json.dump(data, f)
         return 0
 
     def generate(self, server_id: int) -> int:
@@ -34,33 +34,33 @@ class Automod():
                 }
             }
         self.save(automod_config)
-    
+
     def fetch_config(self, server_id: int) -> dict:
         """Fetches and returns the specified server's automod configuration.\n\nReturns in raw `dict` format."""
         automod_config = self.load()
         return automod_config[str(server_id)]
-    
+
     def swearfilter_enabled(self, server_id: int, value: bool) -> int:
         """Sets a `bool` value to define whether the server's swear-filter is enabled or not."""
         automod_config = self.load()
         automod_config[str(server_id)]["swear_filter"]["enabled"] = value
         self.save(automod_config)
         return 0
-    
+
     def swearfilter_usedefaultkeywords(self, server_id: int, enabled: bool) -> int:
         """Sets a `bool` value to define whether the server's swear-filter will use default keywords."""
         automod_config = self.load()
         automod_config[str(server_id)]["swear_filter"]["keywords"]["use_default"] = enabled
         self.save(automod_config)
         return 0
-    
+
     def swearfilter_addkeyword(self, server_id: int, keyword: str) -> int:
         """Adds a new custom keyword for the server's automod configuration."""
         automod_config = self.load()
         automod_config[str(server_id)]["swear_filter"]["keywords"]["custom"].append(keyword)
         self.save(automod_config)
         return 0
-    
+
     def swearfilter_removekeyword(self, server_id: int, keyword_id: int) -> int:
         """Removes a keyword (using id) from the server's automod configuration."""
         automod_config = self.load()

--- a/framework/isobot/db/items.py
+++ b/framework/isobot/db/items.py
@@ -20,7 +20,7 @@ class Items():
 
     def save(self, data: dict) -> int:
         """Dumps all cached data to your local machine."""
-        with open("database/items.json", 'w+', encoding="utf8") as f: json.dump(data, f, indent=4)
+        with open("database/items.json", 'w+', encoding="utf8") as f: json.dump(data, f)
         return 0
 
     def generate(self, user_id: int) -> int:
@@ -49,5 +49,8 @@ class Items():
 
     def fetch_item_count(self, user_id: int, item: str) -> int:
         """Fetches and returns the amount of a specific item owned by the user."""
-        items = self.load()
-        return items[str(user_id)][item]
+        try:
+            items = self.load()
+            #print(items[str(user_id)])
+            return items[str(user_id)][item]
+        except Exception as e: print(e)

--- a/framework/isobot/db/items.py
+++ b/framework/isobot/db/items.py
@@ -49,8 +49,5 @@ class Items():
 
     def fetch_item_count(self, user_id: int, item: str) -> int:
         """Fetches and returns the amount of a specific item owned by the user."""
-        try:
-            items = self.load()
-            #print(items[str(user_id)])
-            return items[str(user_id)][item]
-        except Exception as e: print(e)
+        items = self.load()
+        return items[str(user_id)][item]

--- a/framework/isobot/db/levelling.py
+++ b/framework/isobot/db/levelling.py
@@ -15,7 +15,7 @@ class Levelling():
 
     def save(self, data: dict) -> int:
         """Dumps all cached data to your local machine."""
-        with open("database/levels.json", 'w+', encoding="utf8") as f: json.dump(data, f, indent=4)
+        with open("database/levels.json", 'w+', encoding="utf8") as f: json.dump(data, f)
         return 0
 
     def generate(self, user_id: int) -> int:
@@ -79,7 +79,7 @@ class Levelling():
         """Fetches a user's current xp."""
         levels = self.load()
         return levels[str(user_id)]["xp"]
-    
+
     def get_raw(self):
         """Fetches and returns the raw json data in the levelling database."""
         levels = self.load()

--- a/framework/isobot/db/userdata.py
+++ b/framework/isobot/db/userdata.py
@@ -8,7 +8,7 @@ class UserData():
     """Used to initialize the UserData system."""
     def __init__(self):
         print("[framework/db/UserData] UserData library initialized.")
-    
+
     def load(self) -> dict:
         """Fetches and returns the latest data from the levelling database."""  
         with open("database/user_data.json", 'r', encoding="utf8") as f: db = json.load(f)
@@ -16,9 +16,9 @@ class UserData():
 
     def save(self, data: dict) -> int:
         """Dumps all cached data to your local machine."""
-        with open("database/user_data.json", 'w+', encoding="utf8") as f: json.dump(data, f, indent=4)
+        with open("database/user_data.json", 'w+', encoding="utf8") as f: json.dump(data, f)
         return 0
-    
+
     def generate(self, user_id: int) -> int:
         """Generates a new data key for the specified user.\n
         Returns `0` if the request was successful, returns `1` if the data key already exists."""
@@ -33,7 +33,7 @@ class UserData():
         """Fetches the vakue of a data key, from a specific user."""
         userdat = self.load()
         return userdat[str(user_id)][key]
-    
+
     def set(self, user_id: int, key: str, value) -> int:
         """Sets a new value for a data key, for a specific user."""
         userdat = self.load()

--- a/framework/isobot/db/weather.py
+++ b/framework/isobot/db/weather.py
@@ -23,7 +23,7 @@ class Weather(Colors):
 
     def save(self, data: dict) -> int:
         """Dumps all cached data to your local machine."""
-        with open("database/weather.json", 'w+', encoding="utf-8") as f: json.dump(data, f, indent=4)
+        with open("database/weather.json", 'w+', encoding="utf-8") as f: json.dump(data, f)
         return 0
 
     def new(self, user_id: User):


### PR DESCRIPTION
Previously, when a request was fired to save the isobot databases, the client would add indents to every single line in the database. This does look nice for the eyes, but this also causes major computational overhead (especially when working with the items database), and is one of the main reasons causing the Replit server to crash.

This update removes indenting while saving databases. Now, the databases may not look as nice, but at least it should be able to spare the server a bit.