### PR TITLE
Fix `/status` command failure caused by `avatar_url`

### DIFF
--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -163,7 +163,7 @@ class Utils(commands.Cog):
         localembed.add_field(name="Registered Users", value=f"{bot_users} users", inline=True)
         localembed.add_field(name="Uptime History", value="[here](https://stats.uptimerobot.com/PlKOmI0Aw8)")
         localembed.add_field(name="Release Notes", value="[latest](https://github.com/PyBotDevs/isobot/releases/latest)")
-        localembed.set_footer(text=f"Requested by {ctx.author.name}", icon_url=ctx.author.avatar_url)
+        localembed.set_footer(text=f"Requested by {ctx.author.name}", icon_url=ctx.author.avatar)
         await ctx.respond(embed=localembed)
 
     @commands.slash_command(


### PR DESCRIPTION
Apparently PyCord updated their library to depreciate the `discord.User.avatar_url` reference and switch to `discord.User.avatar`.
I didn't know until I found new bugs in the commands, and I finally read the PyCord documentation again.