### PR TITLE
Allow varying values for pi

### DIFF
--- a/cogs/maths.py
+++ b/cogs/maths.py
@@ -62,11 +62,16 @@ class Maths(commands.Cog):
         description="Finds the area of a circle"
     )
     @option(name="radius", description="What is the radius of the circle?", type=int)
-    async def area_circle(self, ctx: ApplicationContext, radius: int):
+    @option(name="pi", description="Set a value for π (default is 22/7)", type=str, choices=["22/7", "3.14", "3"], default="22/7")
+    async def area_circle(self, ctx: ApplicationContext, radius: int, pi: str = "22/7"):
         if radius < 0: return await ctx.respond("Radius cannot be lower than 0 units.")
-        result = (22/7) * (radius * radius)
+        if pi == "22/7": result = (22/7) * (radius * radius)
+        elif pi == "3.14": result = 3.14 * (radius * radius)
+        elif pi == "3": result = 3 * (radius * radius)
         localembed = discord.Embed(title=f"Area of circle of radius {radius} units", description=f"{result} sq. units", color=color)
-        localembed.set_footer(text=f"Taking π as 22/7\nA = πr²\nπ x {radius}² = {result} sq. units")
+        if pi == "22/7": localembed.set_footer(text=f"Taking π as 22/7\nA = πr²\nπ x {radius}² = {result} sq. units")
+        elif pi == "3.14": localembed.set_footer(text=f"Taking π as 3.14\nA = πr²\nπ x {radius}² = {result} sq. units")
+        elif pi == "3":localembed.set_footer(text=f"Taking π as 3\nA = πr²\nπ x {radius}² = {result} sq. units")
         await ctx.respond(embed=localembed)
     
     @area.command(


### PR DESCRIPTION
This update allows users using the `/area circle` command to set different pi values, including 22/7, 3.14, and 3.