### PR TITLE
Remove item id choices for economy slash commands

### DIFF
--- a/cogs/economy.py
+++ b/cogs/economy.py
@@ -278,8 +278,8 @@ class Economy(commands.Cog):
         name='shop',
         description='Views and buys items from the shop'
     )
-    @option(name="item", description="Specify an item to view.", type=str, default=None, choices=all_item_ids)
-    async def shop(self, ctx: ApplicationContext, item:str=None):
+    @option(name="item", description="Specify an item to view.", type=str, default=None)
+    async def shop(self, ctx: ApplicationContext, item: str=None):
         if item == None:
             localembed = discord.Embed(
                 title='The Shop!',
@@ -304,7 +304,7 @@ class Economy(commands.Cog):
         name='buy',
         description='Buys an item from the shop'
     )
-    @option(name="name", description="What do you want to buy?", type=str, choices=all_item_ids)
+    @option(name="name", description="What do you want to buy?", type=str)
     @option(name="quantity", description="How many do you want to buy?", type=int, default=1)
     async def buy(self, ctx: ApplicationContext, name: str, quantity: int=1):
         try:
@@ -332,7 +332,7 @@ class Economy(commands.Cog):
         name='sell',
         description='Sells an item from your inventory in exchange for cash'
     )
-    @option(name="name", description="What do you want to sell?", type=str, choices=all_item_ids)
+    @option(name="name", description="What do you want to sell?", type=str)
     @option(name="quantity", description="How many do you want to sell?", type=int, default=1)
     async def sell(self, ctx: ApplicationContext, name: str, quantity: int=1):
         try:
@@ -351,7 +351,7 @@ class Economy(commands.Cog):
         description="Gifts a (giftable) item to anyone you want"
     )
     @option(name="user", description="Who do you want to gift to?", type=discord.User)
-    @option(name="item", description="What do you want to gift?", type=str, choices=all_item_ids)
+    @option(name="item", description="What do you want to gift?", type=str)
     @option(name="amount", description="How many of these do you want to gift?", type=int, default=1)
     async def gift(self, ctx: ApplicationContext, user:discord.User, item:str, amount:int=1):
         try:


### PR DESCRIPTION
# Economy Commands Update
Apparently, the Discord API can only make a slash command with a maximum of 25 choices.

After the addition of multiple new items, the `item ids` count has exceeded 25 items, which runs into Discord's slash command limitation and prevents commands from being synced to the bot.

Hence, item id selectors have been removed from all economy slash commands as a counteractive measure. For reference, all item ids can be viewed and searched from through the new `/all_item_ids` command.