### PR TITLE
Allow pinging server deployment to be overridden through runtime options

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,8 +96,6 @@ This is free software, and you are welcome to redistribute it
 under certain conditions.
 __________________________________________________""")
     time.sleep(1)
-    print("[main/Flask] Starting pinger service...")
-    ping.host()
     if api.auth.get_runtime_options()["show_ping_on_startup"]:
         s.log("Client Information:")
         s.log(f"   Latency/Ping: {round((client.latency * 1000), 2)} ms")
@@ -105,6 +103,10 @@ __________________________________________________""")
     s.log(f'[main/Client] Logged in as {client.user.name}. Start time: {start_time.strftime("%H:%M:%S")}\n[main/Client] Ready to accept commands. Click Ctrl+C to shut down the bot.')
     await client.change_presence(activity=discord.Activity(type=discord.ActivityType.playing, name="Isobot is finally back! Improved uptime!"), status=discord.Status.idle)
     s.log(f'[main/Log] {colors.green}Status set to IDLE. Rich presence set.{colors.end}')
+    if api.auth.get_mode() or api.auth.get_runtime_options()["ping_server_override"]:
+        # If ping_server_override is set to true, it will start the pinging server no matter what. If it's set to false, it will only start if client mode is set to replit.
+        s.log(f"[main/Flask] {f'{colors.yellow}Ping server override.{colors.end} ' if api.auth.get_runtime_options()['ping_server_override'] else ''}Starting pinger service...")
+        ping.host()
     time.sleep(5)
 
 @client.event


### PR DESCRIPTION
### What is this?
This allows the bot's pinging server to be deployed, even when Replit mode is disabled through runtime options configuration. This is useful for local bot deployments, if the server's local ip is used to track client uptime, etc.

### How to enable the override?
Go to `api/runtimeconfig.json`, and set `ping_server_override=true`