### PR TITLE
Fix issue in `/automod` where server icon fails to display

### DIFF
--- a/cogs/automod.py
+++ b/cogs/automod.py
@@ -22,7 +22,7 @@ class Automod(commands.Cog):
     async def automod(self, ctx: ApplicationContext):
         loaded_config = automod.fetch_config(ctx.guild.id)
         localembed = discord.Embed(title=f"{ctx.guild.name}\'s automod configuration", description="Use the `/automod_set` command to change your server's automod configuration.", color=color)
-        localembed.set_thumbnail(url=ctx.guild.icon_url)
+        localembed.set_thumbnail(url=ctx.guild.icon)
         localembed.add_field(name="Swear-filter", value=loaded_config["swear_filter"]["enabled"])
         localembed.add_field(name="Swear-filter Keywords Count", value=f"{int(len(loaded_config['swear_filter']['keywords']['default'])) + int(len(loaded_config['swear_filter']['keywords']['custom']))} words")
         localembed.set_footer(text="More automod features will come soon!")


### PR DESCRIPTION
Basically update the attribute name for guild icon in order to fetch it and display it in the embed correctly, because Pycord changed the `icon_url` attribute which led to an `AttributeError` and that led to an embed creation exception, which led to the whole command failing. Anyway, thankfully, its all fixed now. 😌 

This is what happens when you update Pycord.