### PR TITLE
FINALLY enable the `message_content` intent flag for the bot client

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,9 @@ from discord.ext import commands
 from cogs.isocoin import create_isocoin_key
 
 # Variables
-client = discord.Bot()
+intents = discord.Intents.default()
+intents.message_content = True
+client = discord.Bot(intents=intents)
 color = discord.Color.random()
 start_time = ""
 


### PR DESCRIPTION
# Backstory of the Most Major and Longest-Lasting Bug in Isobot
Two years.

I'm not even going to lie, this bug was there in the bot since the very beginning of the codebase rework.

It was absolutely haunting. It used to make me think every night: "How would I be able to fix this?"

No amount of ChatGPT debugging or documentation resolution was able to provide me with a solution for it. Eventually, I landed on the conclusion that I wouldn't be able to fix it, and I just left it, allowing the AFK system and the automod features to rot in the dark.

But finally, after some time of thinking with a fresh and rejuvenated mind, after 2 whole years, I was finally able to find a fix for it... and the fix was only 3 lines long.

Turns out it was that in PyCord's latest update they turned `discord.Bot()` into a `discord.Client()` replica by adding its arguments, so now basically its just like the old version: make an intents object, enable `intents.message_content` flag, and add it as an argument to `discord.Bot()`.

Finally.

:relieved:

# Fixed Features from this PR
This patch helps fix the ongoing bugs with the user AFK notifier, and all of isobot's automod features. 