### PR TITLE
Add a server warning system to let server staff warn their members for certain activity

### DIFF
--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -114,5 +114,19 @@ class Moderation(commands.Cog):
             color=discord.Color.random()
         )
         await ctx.respond(embed=localembed)
+
+    # User App Commands
+    @commands.user_command(
+        name="Clear All Warnings"
+    )
+    async def _clear_all_warnings(self, ctx: ApplicationContext, user: discord.Member):
+        await self.clear_all_warning(ctx, user)
+    
+    @commands.user_command(
+        name="Show Warnings"
+    )
+    async def _show_warnings(self, ctx: ApplicationContext, user: discord.Member):
+        await self.show_warnings(ctx, user)
+
 # Initialization
 def setup(bot): bot.add_cog(Moderation(bot))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -70,5 +70,24 @@ class Moderation(commands.Cog):
         )
         await ctx.respond(embed=localembed)
 
+    @commands.slash_command(
+        name="clear_all_warnings",
+        description="Clears all the warnings from the specified user."
+    )
+    @option(name="user", description="The user whose warnings you want to clear.", type=discord.Member)
+    async def clear_all_warning(self, ctx: ApplicationContext, user: discord.Member):
+        """Clears all the warnings from the specified user."""
+        if not ctx.author.guild_permissions.manage_messages:
+            return await ctx.respond(
+                """You can't use this command! You need the `Manage Messages` permission to run this.
+                If you think this is a mistake, contact your server administrator.""",
+                ephemeral=True
+            )
+        warningsdb.clear_all_warnings(ctx.guild.id, user.id)
+        localembed = discord.Embed(
+            description=f":white_check_mark: Successfully cleared all server warnings for **{user.display_name}**.",
+            color=discord.Color.green()
+        )
+        await ctx.respond(embed=localembed)
 # Initialization
 def setup(bot): bot.add_cog(Moderation(bot))

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -89,5 +89,30 @@ class Moderation(commands.Cog):
             color=discord.Color.green()
         )
         await ctx.respond(embed=localembed)
+    
+    @commands.slash_command(
+        name="show_warnings",
+        description="See all the server warnings for a specific user."
+    )
+    @option(name="user", description="The user whose warnings you want to view.", type=discord.Member, default=None)
+    async def show_warnings(self, ctx: ApplicationContext, user: discord.Member = None):
+        """See all the server warnings for a specific user."""
+        await ctx.defer()
+        if user == None: user = ctx.author
+        all_user_warnings = warningsdb.fetch_all_warnings(ctx.guild.id, user.id)
+        parsed_output = str()
+        count = int()
+        for warning in all_user_warnings:
+            count += 1
+            mod_ctx = await ctx.bot.fetch_user(warning["moderator_id"])
+            parsed_output += f"{count}. **Warned by {mod_ctx.display_name}**\n> Reason: {warning['reason']}\n> Time Since Warn: <t:{warning['warning_ts']}:R>\n"
+        if parsed_output == "":
+            parsed_output = "*Nothing to see here...*"
+        localembed = discord.Embed(
+            title=f"All warnings for **{user.display_name}** in **{ctx.guild.name}**",
+            description=parsed_output,
+            color=discord.Color.random()
+        )
+        await ctx.respond(embed=localembed)
 # Initialization
 def setup(bot): bot.add_cog(Moderation(bot))

--- a/framework/isobot/db/warnings.py
+++ b/framework/isobot/db/warnings.py
@@ -1,0 +1,56 @@
+"""The framework module library used for managing isobot's warnings database."""
+
+# Imports
+import json
+from framework.isobot.colors import Colors as colors
+
+# Functions
+class Warnings:
+    """Used to initialize the warnings database."""
+    def __init__(self):
+        print(f"[framework/db/Warnings] {colors.green}Warnings db library initialized.{colors.end}")
+
+    def load(self) -> dict:
+        """Fetches and returns the latest data from the warnings database."""
+        with open("database/warnings.json", 'r', encoding="utf8") as f: db = json.load(f)
+        return db
+
+    def save(self, data: dict) -> int:
+        """Dumps all cached data to your local machine."""
+        with open("database/warnings.json", 'w+', encoding="utf8") as f: json.dump(data, f)
+        return 0
+    
+    def generate(self, guild_id: int, user_id: int) -> int:
+        """Generates a new database key for the user in the specified guild.\n\nReturns `0` if generation is successful."""
+        data = self.load()
+        if str(guild_id) not in data:
+            data[str(guild_id)] = {}
+        if str(user_id) not in data[str(guild_id)]:
+            data[str(guild_id)][str(user_id)] = []
+        self.save(data)
+        return 0
+
+    def add_warning(self, guild_id: int, user_id: int, moderator_id: int, warning_ts: int, reason: str) -> dict:
+        """Adds a new warning entry to the user of the specified guild, in the database.\n\nReturns the warning data as a `dict`."""
+        data = self.load()
+        # TODO: Add warning ids later. For now, just keep warnings in a list variable.
+        warning_data = {
+            "moderator_id": moderator_id,
+            "warning_ts": warning_ts,
+            "reason": reason
+        }
+        data[str(guild_id)][str(user_id)].append(warning_data)
+        self.save(data)
+        return warning_data
+    
+    def clear_all_warnings(self, guild_id: int, user_id: int) -> int:
+        """Clears all the warnings for the user in the specified guild."""
+        data = self.load()
+        data[str(guild_id)][str(user_id)] = []
+        self.save(data)
+        return 0
+
+    def fetch_all_warnings(self, guild_id: int, user_id: int) -> list:
+        """Returns a `list` of all the warnings of the user in a specific guild."""
+        data = self.load()
+        return data[str(guild_id)][str(user_id)]

--- a/framework/isobot/db/warnings.py
+++ b/framework/isobot/db/warnings.py
@@ -33,7 +33,6 @@ class Warnings:
     def add_warning(self, guild_id: int, user_id: int, moderator_id: int, warning_ts: int, reason: str) -> dict:
         """Adds a new warning entry to the user of the specified guild, in the database.\n\nReturns the warning data as a `dict`."""
         data = self.load()
-        # TODO: Add warning ids later. For now, just keep warnings in a list variable.
         warning_data = {
             "moderator_id": moderator_id,
             "warning_ts": warning_ts,

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from math import floor
 from random import randint
 from framework.isobot import currency, colors, settings, commands as _commands
 from framework.isobot.shop import ShopData
-from framework.isobot.db import levelling, items, userdata, automod, weather, presence as _presence
+from framework.isobot.db import levelling, items, userdata, automod, weather, warnings, presence as _presence
 from discord import ApplicationContext, option
 from discord.ext import commands
 from cogs.isocoin import create_isocoin_key
@@ -103,6 +103,7 @@ currency = currency.CurrencyAPI("database/currency.json", "logs/currency.log")
 settings = settings.Configurator()
 levelling = levelling.Levelling()
 items = items.Items()
+warningsdb = warnings.Warnings()
 userdata = userdata.UserData()
 automod = automod.Automod()
 _presence = _presence.Presence()
@@ -185,7 +186,9 @@ async def on_message(ctx):
         settings.generate(ctx.author.id)
         items.generate(ctx.author.id)
         levelling.generate(ctx.author.id)
-        try: automod.generate(ctx.guild.id)
+        try:
+            automod.generate(ctx.guild.id)
+            warningsdb.generate(ctx.guild.id, ctx.author.id)
         except AttributeError: pass
 
         try:

--- a/main.py
+++ b/main.py
@@ -40,7 +40,19 @@ def initial_setup():
 
     # Generating database files
     try:
-        databases = ["automod", "currency", "isocard", "items", "levels", "presence", "user_data", "weather", "isobank/accounts", "isobank/auth"]
+        databases = [
+            "automod",
+            "currency",
+            "isocard",
+            "items",
+            "levels",
+            "warnings",
+            "presence",
+            "user_data",
+            "weather",
+            "isobank/accounts",
+            "isobank/auth"
+        ]
         for f in databases:
             if not os.path.isfile(f"database/{f}.json"):
                 logger.warn(f"[main/Setup] '{f}.json' was not found in database directory. Creating new database...", module="main/Setup", nolog=True)


### PR DESCRIPTION
# The Warning System!
## About
This is a pretty neat and useful moderation feature which lets server and community owners, admin, moderators, and other staff warn their server members for doing activity that breaks their rules, warning for fun (we wont judge), or for other reasons too.

## Commands
- `/warn`: The basic warning system feature. This command can only be used by people with the `Manage Messages` permission in the server. This command warns a user for a specific reason by sending them a DM, as well as logging it to the server warnings log.
- `/clear_all_warnings`: This command basically lets staff with the `Manage Messages` permission in the server to clear all warnings from a specific user. This will wipe their name clean from the server warnings log, but it won't delete any of their warning DMs. (maybe use this if they behave good after some time?)
- `/show_warnings`: Unlike the other two commands, this command can be used by any server member (who can use bot commands). This command is used to see all the logged warnings of a specific user (or themselves) from the server's warnings log. With this command you can only see other's warnings, not edit them.