### PR TITLE
Add `/serverinfo` command to provide detailed information about a specific server

### DIFF
--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -364,7 +364,6 @@ class Utils(commands.Cog):
             name="Custom Expressions (emojis/stickers)",
             value=f"{len(await ctx.guild.fetch_emojis())} emojis | {len(await ctx.guild.fetch_stickers())} stickers"
         )
-        
         await ctx.respond(embed=localembed)
 
     commandmanager = SlashCommandGroup("commandmanager", "Manage isobot's command registry.")

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -318,6 +318,46 @@ class Utils(commands.Cog):
         await new_channel.send(f"Channel nuked by **{ctx.author.name}**!")
         await ctx.respond(embed=localembed, ephemeral=True)
 
+    @commands.slash_command(
+        name="serverinfo",
+        description="Get detailed information about the server."
+    )
+    @commands.guild_only()
+    async def serverinfo(self, ctx: ApplicationContext):
+        """Get detailed information about the server."""
+        localembed = discord.Embed(
+            title=f"Server info on **{ctx.guild.name}**",
+            description=f"*{ctx.guild.description}*" if ctx.guild.description is not None else '',
+            color=discord.Color.random()
+        )
+        localembed.set_thumbnail(url=ctx.guild.icon)
+        localembed.set_footer(text=f"Server ID: {ctx.guild.id}")
+        if ctx.guild.banner is not None:
+            localembed.set_image(url=ctx.guild.banner)
+        
+        # Server Info Fields
+        localembed.add_field(name="Server Created On", value=ctx.guild.created_at.strftime("%b %d, %Y, %T"))
+        localembed.add_field(name="Member Count", value=f"{ctx.guild.member_count} members")
+        localembed.add_field(name="Server Owner", value=f"<@!{ctx.guild.owner_id}>")
+        localembed.add_field(
+            name="Total Number of Channels",
+            value=f"{len(ctx.guild.channels)-len(ctx.guild.categories)} channels\n({len(ctx.guild.text_channels)} Text | {len(ctx.guild.voice_channels)} Voice | {len(ctx.guild.forum_channels)} Forums)",
+            inline=True
+        )
+        localembed.add_field(name="Total Number of Roles", value=f"{len(ctx.guild.roles)-1} roles")
+        localembed.add_field(name="Currently Active Threads", value=f"{len(await ctx.guild.active_threads())} threads")
+        localembed.add_field(
+            name="Active Invite Links",
+            value=f"{len(await ctx.guild.invites())} links {'(invites disabled)' if ctx.guild.invites_disabled else ''}"
+        )
+        localembed.add_field(name="Server Verification Level", value=ctx.guild.verification_level, inline=True)
+        localembed.add_field(
+            name="Custom Expressions (emojis/stickers)",
+            value=f"{len(await ctx.guild.fetch_emojis())} emojis | {len(await ctx.guild.fetch_stickers())} stickers"
+        )
+        
+        await ctx.respond(embed=localembed)
+
     commandmanager = SlashCommandGroup("commandmanager", "Manage isobot's command registry.")
 
     @commandmanager.command(

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -345,7 +345,16 @@ class Utils(commands.Cog):
             inline=True
         )
         localembed.add_field(name="Total Number of Roles", value=f"{len(ctx.guild.roles)-1} roles")
-        localembed.add_field(name="Currently Active Threads", value=f"{len(await ctx.guild.active_threads())} threads")
+        threads = await ctx.guild.active_threads()
+        threads_display_list = str()
+        if len(threads) <= 4:  # Display threads if total threads count is under 5
+            for thread in threads:
+                threads_display_list += f"<#{thread.id}>, "
+            threads_display_list = threads_display_list.rstrip(", ")  # Removing the final "," from the string
+        localembed.add_field(
+            name="Currently Active Threads",
+            value=f"{len(await ctx.guild.active_threads())} threads {f'({threads_display_list})' if threads_display_list != '' else ''}"
+        )
         localembed.add_field(
             name="Active Invite Links",
             value=f"{len(await ctx.guild.invites())} links {'(invites disabled)' if ctx.guild.invites_disabled else ''}"

--- a/config/commands.json
+++ b/config/commands.json
@@ -838,5 +838,15 @@
     "usable_by": "server admins",
     "disabled": false,
     "bugged": false
-    }
+  },
+  "serverinfo": {
+    "name": "Server Info",
+    "description": "Get detailed information about the server.",
+    "type": "general utilities",
+    "cooldown": null,
+    "args": null,
+    "usable_by": "everyone",
+    "disabled": false,
+    "bugged": false
+  }
 }

--- a/main.py
+++ b/main.py
@@ -267,6 +267,7 @@ async def on_application_command_error(ctx: ApplicationContext, error: discord.D
         elif isinstance(error, commands.BadArgument): await ctx.respond(":x: Invalid argument.", ephemeral=True)
         elif isinstance(error, commands.BotMissingPermissions): await ctx.respond(":x: I don\'t have the required permissions to use this.\nIf you think this is a mistake, please go to server settings and fix isobot's role permissions.")
         elif isinstance(error, commands.BadBoolArgument): await ctx.respond(":x: Invalid true/false argument.", ephemeral=True)
+        elif isinstance(error, commands.NoPrivateMessage): await ctx.respond(":x: You can only use this command in a server!", ephemeral=True)
         else:
             logger.error(f"Command failure: An uncaught error occured while running the command.\n   >>> {error}", module="main/Client")
             await ctx.respond(f"An uncaught error occured while running the command. (don't worry, developers will fix this soon)\n```\n{error}\n```")


### PR DESCRIPTION
## ServerInfo Command
This command provides detailed information about a specific server, consisting of information like
- Server Creation Date
- Member Count
- Server Owner
- Number of Different Channel Types
- Roles
- Threads
- Invite links
- Server Verification Level
- Custom Expressions (emojis, stickers)