### PR TITLE
Add ability to send level-up messages to a server channel, instead of user DMs

### DIFF
--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -39,6 +39,31 @@ class ServerConfig(commands.Cog):
                 color=discord.Color.green()
             )
         await ctx.respond(embed=localembed)
+    
+    @serverconfig_cmds.command(
+        name="levelup_override_channel",
+        description="Set a server channel to send level-up messages to, instead of DMs."
+    )
+    @option(name="channel", description="The channel in which you want level-up messages to be sent.", type=discord.TextChannel, default=None)
+    async def autorole(self, ctx: ApplicationContext, channel: discord.TextChannel = None):
+        """Set a role to provide to all newly-joined members of the server."""
+        if not ctx.author.guild_permissions.manage_guild:
+            return await ctx.respond("You can't use this command! You need the `Manage Server` permission to run this.", ephemeral=True)
+        if channel != None:
+            serverconf.set_levelup_override_channel(ctx.guild.id, channel.id)
+            localembed = discord.Embed(
+                title=f":white_check_mark: Level-up Override Channel successfully set for **{ctx.guild.name}**!",
+                description=f"From now onwards, all new level-up messages for members in this server will be sent to {channel.mention}, instead of user DMs.",
+                color=discord.Color.green()
+            )
+        else:
+            serverconf.set_levelup_override_channel(ctx.guild.id, None)
+            localembed = discord.Embed(
+                title=f":white_check_mark: Level-up Override Channel successfully disabled for **{ctx.guild.name}**",
+                description="All new level-up messages will be sent to user DMs.",
+                color=discord.Color.green()
+            )
+        await ctx.respond(embed=localembed)
 
 def setup(bot):
     bot.add_cog(ServerConfig(bot))

--- a/framework/isobot/db/serverconfig.py
+++ b/framework/isobot/db/serverconfig.py
@@ -32,7 +32,8 @@ class ServerConfig:
                 "goodbye_message": {
                     "channel": None,
                     "message": None
-                }
+                },
+                "level_up_override_channel": None
             }
             self.save(serverconf)
         return 0
@@ -43,7 +44,7 @@ class ServerConfig:
         return serverconf[str(server_id)]
     
     def fetch_autorole(self, server_id: int) -> str:
-        """Fetch the specified autorole for the server. Returns `None` if not set."""
+        """Fetches the specified autorole for the server. Returns `None` if not set."""
         return self.fetch_raw(server_id)["autorole"]
     
     def fetch_welcome_message(self, server_id: int) -> dict:
@@ -53,6 +54,10 @@ class ServerConfig:
     def fetch_goodbye_message(self, server_id: int) -> dict:
         """Fetches the goodbye message and set channel for the server as `dict`.\n\nReturns `None` for `channel` and `message` values if not set."""
         return self.fetch_raw(server_id)["goodbye_message"]
+    
+    def fetch_levelup_override_channel(self, server_id: int) -> str:
+        """Fetches the level-up override channel for the specified guild. Returns `None` if not set."""
+        return self.fetch_raw(server_id)["level_up_override_channel"]
 
     def set_autorole(self, server_id: int, role_id: int) -> int:
         """Sets a role id to use as autorole for the specified guild. Returns `0` if successful."""
@@ -72,4 +77,10 @@ class ServerConfig:
         serverconf = self.load()
         serverconf[str(server_id)]["goodbye_message"]["channel"] = channel_id
         serverconf[str(server_id)]["goodbye_message"]["message"] = message
+        self.save(serverconf)
+    
+    def set_levelup_override_channel(self, server_id: int, channel_id: int) -> int:
+        """Sets a level-up override channel id for the specified guild. Returns `0` if successful."""
+        serverconf = self.load()
+        serverconf[str(server_id)]["level_up_override_channel"] = channel_id
         self.save(serverconf)

--- a/main.py
+++ b/main.py
@@ -263,7 +263,11 @@ async def on_message(ctx):
             levelling.add_levels(ctx.author.id, 1)
             if settings.fetch_setting(ctx.author.id, "levelup_messages") is True:
                 try:
-                    await ctx.author.send(f"{ctx.author.mention}, you just ranked up to **level {levelling.get_level(ctx.author.id)}**. Nice!\n\n{':bulb: Tip: This is your global message level and is the same across all servers. If you want to disable DMs for levelling up, run `/settings levelup_messages enabled: False`' if levelling.get_level(ctx.author.id) == 1 else ''}")
+                    if serverconfig.fetch_levelup_override_channel(ctx.guild.id) is None:
+                        await ctx.author.send(f"{ctx.author.mention}, you just ranked up to **level {levelling.get_level(ctx.author.id)}**. Nice!\n\n{':bulb: Tip: This is your global message level and is the same across all servers. If you want to disable DMs for levelling up, run `/settings levelup_messages enabled: False`' if levelling.get_level(ctx.author.id) == 1 else ''}")
+                    else:
+                        channel = await client.get_channel(int(serverconfig.fetch_levelup_override_channel(ctx.guild.id)))
+                        await channel.send(f"{ctx.author.mention}, you just ranked up to **level {levelling.get_level(ctx.author.id)}**. Nice!\n\n{':bulb: Tip: This is your global message level and is the same across all servers. If you want to disable messages for levelling up, run `/settings levelup_messages enabled: False`' if levelling.get_level(ctx.author.id) == 1 else ''}")
                 except discord.errors.Forbidden:
                     # Error is raised when the user isnt accepting DMs (or has blocked isobot)
                     # In that case isobot will automatically stop sending levelup messages to them


### PR DESCRIPTION
# Level-up Messages Override Channel
Done through the `/serverconfig levelup_override_channel` command. This basically overrides the DM level-up messages and sends the message to a specified server channel instead.

This can be enabled or disabled at any time by members with the `Manage Guild` permission.