### PR TITLE
Set a few bot slash commands as server-only

### DIFF
--- a/cogs/afk.py
+++ b/cogs/afk.py
@@ -22,6 +22,7 @@ class PresenceCog(commands.Cog):
         name="set",
         description="Sets your AFK status with a custom response"
     )
+    @commands.guild_only()
     @option(name="response", description="What do you want your AFK response to be?", type=str, default="I'm AFK")
     async def afk_set(self, ctx: ApplicationContext, response: str="I'm AFK"):
         presence.add_afk(ctx.guild.id, ctx.user.id, response)
@@ -32,6 +33,7 @@ class PresenceCog(commands.Cog):
         name="remove",
         description="Removes your AFK status"
     )
+    @commands.guild_only()
     async def afk_remove(self, ctx: ApplicationContext):
         status = presence.remove_afk(ctx.guild.id, ctx.author.id)
         if status == 0: return await ctx.respond(f"Alright {ctx.author.mention}, I've removed your AFK.")
@@ -41,6 +43,7 @@ class PresenceCog(commands.Cog):
         name="mod_remove",
         description="Removes an AFK status for someone else"
     )
+    @commands.guild_only()
     @option(name="user", description="Whose AFK status do you want to remove?", type=discord.User)
     async def afk_mod_remove(self, ctx: ApplicationContext, user:discord.User):
         if not ctx.author.guild_permissions.manage_messages: return await ctx.respond("You don't have the required permissions to use this.", ephemeral=True)

--- a/cogs/automod.py
+++ b/cogs/automod.py
@@ -22,6 +22,7 @@ class Automod(commands.Cog):
         name="config",
         description="Shows the current automod configuration for your server"
     )
+    @commands.guild_only()
     async def automod_config(self, ctx: ApplicationContext):
         loaded_config = automod.fetch_config(ctx.guild.id)
         localembed = discord.Embed(title=f"{ctx.guild.name}\'s automod configuration", description="Use the `/automod_set` command to change your server's automod configuration.", color=color)
@@ -36,6 +37,7 @@ class Automod(commands.Cog):
         name="swearfilter",
         description="Turn on or off automod's swear-filter in your server"
     )
+    @commands.guild_only()
     @option(name="toggle", description="Do you want to turn it on or off?", type=bool)
     async def automod_swearfilter(self, ctx: ApplicationContext, toggle: bool):
         if not ctx.author.guild_permissions.administrator: return await ctx.respond("You cannot use this command. If you think this is a mistake, please contact your server owner/administrator.", ephemeral=True)
@@ -48,6 +50,7 @@ class Automod(commands.Cog):
         name="use_default_keywords",
         description="Choose whether or not you want to use the default keywords for automod's swear-filter"
     )
+    @commands.guild_only()
     @option(name="toggle", description="Do you want to turn it on or off?", type=bool)
     async def automod_use_default_keywords(self, ctx: ApplicationContext, toggle: bool):
         if not ctx.author.guild_permissions.administrator: return await ctx.respond("You cannot use this command. If you think this is a mistake, please contact your server owner/administrator.", ephemeral=True)
@@ -60,6 +63,7 @@ class Automod(commands.Cog):
         name="view_custom_keywords",
         description="Shows a list of the custom automod swear-filter keywords set for your server",
     )
+    @commands.guild_only()
     async def automod_view_custom_keywords(self, ctx: ApplicationContext):
         loaded_config = automod.fetch_config(ctx.guild.id)
         out = ""
@@ -77,6 +81,7 @@ class Automod(commands.Cog):
         name="add_custom_keyword",
         description="Adds a custom keyword to your server's swear-filter"
     )
+    @commands.guild_only()
     @option(name="keyword", description="What keyword do you want to add?", type=str)
     async def automod_add_custom_keyword(self, ctx: ApplicationContext, keyword:str):
         if not ctx.author.guild_permissions.administrator: return await ctx.respond("You cannot use this command. If you think this is a mistake, please contact your server owner/administrator.", ephemeral=True)
@@ -91,6 +96,7 @@ class Automod(commands.Cog):
         name="remove_custom_keyword",
         description="Removes a custom keyword (matching its id) from your server's swear-filter"
     )
+    @commands.guild_only()
     @option(name="id", description="What's the id of the keyword to remove (can be found through /automod_view_custom_keywords", type=int)
     async def automod_remove_custom_keyword(self, ctx: ApplicationContext, id: int):
         if not ctx.author.guild_permissions.administrator: return await ctx.respond("You cannot use this command. If you think this is a mistake, please contact your server owner/administrator.", ephemeral=True)
@@ -104,6 +110,7 @@ class Automod(commands.Cog):
         name="linkblocker",
         description="Turn on or off automod's link blocker in your server"
     )
+    @commands.guild_only()
     @option(name="toggle", description="Do you want to turn it on or off?", type=bool)
     async def automod_linkblocker(self, ctx: ApplicationContext, toggle: bool):
         if not ctx.author.guild_permissions.administrator: return await ctx.respond("You cannot use this command. If you think this is a mistake, please contact your server owner/administrator.", ephemeral=True)
@@ -116,6 +123,7 @@ class Automod(commands.Cog):
         name="linkblocker_only_whitelisted",
         description="Only allows whitelisted links in the server and blocks all other links"
     )
+    @commands.guild_only()
     @option(name="toggle", description="Do you want to turn it on or off?", type=bool)
     async def automod_linkblocker_only_whitelisted_links(self, ctx: ApplicationContext, toggle: bool):
         if not ctx.author.guild_permissions.administrator: return await ctx.respond("You cannot use this command. If you think this is a mistake, please contact your server owner/administrator.", ephemeral=True)
@@ -128,6 +136,7 @@ class Automod(commands.Cog):
         name="linkblocker_add_whitelist",
         description="Adds a link to your server link blocker's whitelist."
     )
+    @commands.guild_only()
     @option(name="link", description="The link that you want to add (must be in form of https://{url})", type=str)
     async def automod_linkblocker_add_whitelist(self, ctx: ApplicationContext, link: str):
         if not ctx.author.guild_permissions.administrator: return await ctx.respond("You cannot use this command. If you think this is a mistake, please contact your server owner/administrator.", ephemeral=True)
@@ -141,6 +150,7 @@ class Automod(commands.Cog):
         name="linkblocker_add_blacklist",
         description="Adds a link to your server link blocker's blacklist."
     )
+    @commands.guild_only()
     @option(name="link", description="The link that you want to add (must be in form of https://{url})", type=str)
     async def automod_linkblocker_add_blacklist(self, ctx: ApplicationContext, link: str):
         if not ctx.author.guild_permissions.administrator: return await ctx.respond("You cannot use this command. If you think this is a mistake, please contact your server owner/administrator.", ephemeral=True)
@@ -154,6 +164,7 @@ class Automod(commands.Cog):
         name="linkblocker_view_whitelisted",
         description="Shows a list of the whitelisted links set for this server",
     )
+    @commands.guild_only()
     async def automod_view_custom_keywords(self, ctx: ApplicationContext):
         loaded_config = automod.fetch_config(ctx.guild.id)
         out = ""
@@ -171,6 +182,7 @@ class Automod(commands.Cog):
         name="linkblocker_view_blacklisted",
         description="Shows a list of the blacklisted links set for this server",
     )
+    @commands.guild_only()
     async def automod_view_custom_keywords(self, ctx: ApplicationContext):
         loaded_config = automod.fetch_config(ctx.guild.id)
         out = ""
@@ -188,6 +200,7 @@ class Automod(commands.Cog):
         name="linkblocker_remove_blacklist",
         description="Removes a blacklisted link (matching its id) from this server's link blocker"
     )
+    @commands.guild_only()
     @option(name="id", description="What's the id of the link to remove? (can be found through /automod_view_blacklisted_links", type=int)
     async def automod_linkblocker_remove_blacklist(self, ctx: ApplicationContext, id: int):
         if not ctx.author.guild_permissions.administrator: return await ctx.respond("You cannot use this command. If you think this is a mistake, please contact your server owner/administrator.", ephemeral=True)
@@ -200,6 +213,7 @@ class Automod(commands.Cog):
         name="linkblocker_remove_whitelist",
         description="Removes a whitelisted link (matching its id) from this server's link blocker"
     )
+    @commands.guild_only()
     @option(name="id", description="What's the id of the link to remove? (can be found through /automod_view_whitelisted_links", type=int)
     async def automod_linkblocker_remove_whitelist(self, ctx: ApplicationContext, id: int):
         if not ctx.author.guild_permissions.administrator: return await ctx.respond("You cannot use this command. If you think this is a mistake, please contact your server owner/administrator.", ephemeral=True)

--- a/cogs/moderation.py
+++ b/cogs/moderation.py
@@ -17,6 +17,7 @@ class Moderation(commands.Cog):
         name='kick', 
         description='Kicks a member from this server.'
     )
+    @commands.guild_only()
     @option(name="user", description="Who do you want to kick?", type=discord.User)
     @option(name="reason", description="Why do you want to kick the user?", type=str, default=None)
     @commands.cooldown(1, 3, commands.BucketType.user)
@@ -31,6 +32,7 @@ class Moderation(commands.Cog):
         name='ban', 
         description='Bans a member from this server.'
     )
+    @commands.guild_only()
     @option(name="user", description="Who do you want to ban?", type=discord.User)
     @option(name="reason", description="Why you want to ban the user?", type=str, default=None)
     @commands.cooldown(1, 3, commands.BucketType.user)
@@ -47,6 +49,7 @@ class Moderation(commands.Cog):
         name="warn",
         description="Warns the specified user, with a specific reason."
     )
+    @commands.guild_only()
     @option(name="user", description="Who do you want to warn?", type=discord.Member)
     @option(name="reason", description="The reason why you are warning the user", type=str)
     async def warn(self, ctx: ApplicationContext, user: discord.Member, reason: str):
@@ -74,6 +77,7 @@ class Moderation(commands.Cog):
         name="clear_all_warnings",
         description="Clears all the warnings from the specified user."
     )
+    @commands.guild_only()
     @option(name="user", description="The user whose warnings you want to clear.", type=discord.Member)
     async def clear_all_warning(self, ctx: ApplicationContext, user: discord.Member):
         """Clears all the warnings from the specified user."""
@@ -94,6 +98,7 @@ class Moderation(commands.Cog):
         name="show_warnings",
         description="See all the server warnings for a specific user."
     )
+    @commands.guild_only()
     @option(name="user", description="The user whose warnings you want to view.", type=discord.Member, default=None)
     async def show_warnings(self, ctx: ApplicationContext, user: discord.Member = None):
         """See all the server warnings for a specific user."""

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -25,6 +25,7 @@ class ServerConfig(commands.Cog):
         name="autorole",
         description="Set a role to provide to all newly-joined members of the server."
     )
+    @commands.guild_only()
     @option(name="role", description="The role that you want to automatically give to all new members.", type=discord.Role, default=None)
     async def autorole(self, ctx: ApplicationContext, role: discord.Role = None):
         """Set a role to provide to all newly-joined members of the server."""
@@ -50,6 +51,7 @@ class ServerConfig(commands.Cog):
         name="levelup_override_channel",
         description="Set a server channel to send level-up messages to, instead of DMs."
     )
+    @commands.guild_only()
     @option(name="channel", description="The channel in which you want level-up messages to be sent.", type=discord.TextChannel, default=None)
     async def autorole(self, ctx: ApplicationContext, channel: discord.TextChannel = None):
         """Set a role to provide to all newly-joined members of the server."""
@@ -76,6 +78,7 @@ class ServerConfig(commands.Cog):
         name="enable_verification",
         description="Enable new member verification for this server."
     )
+    @commands.guild_only()
     @option(name="verified_role", description="The role to provide to all verified members.", type=discord.Role)
     async def enable_verification(self, ctx: ApplicationContext, verified_role: discord.Role):
         """Enable new user verification for this server."""
@@ -93,6 +96,7 @@ class ServerConfig(commands.Cog):
         name="disable_verification",
         description="Disable new member verification for this server."
     )
+    @commands.guild_only()
     async def disable_verification(self, ctx: ApplicationContext):
         """Disable new member verification for this server."""
         if not ctx.author.guild_permissions.administrator:

--- a/cogs/utils.py
+++ b/cogs/utils.py
@@ -100,6 +100,7 @@ class Utils(commands.Cog):
         name='whoami',
         description='Shows information on a user.'
     )
+    @commands.guild_only()
     @option(name="user", description="Who do you want to know about?", type=discord.User, default=None)
     async def whoami(self, ctx: ApplicationContext, user: discord.User=None):
         """Shows information on a user."""
@@ -301,6 +302,7 @@ class Utils(commands.Cog):
         name="nuke",
         description="Completely wipes a text channel in the server."
     )
+    @commands.guild_only()
     @option(name="channel", description="The channel you want to nuke.", type=discord.TextChannel)
     async def nuke(self, ctx: ApplicationContext, channel: discord.TextChannel):
         """Completely wipes a text channel in the server."""


### PR DESCRIPTION
This will help prevent unexpected errors due to lack of guild data by running commands in isobot DMs, for commands that require information about guilds (servers).