### PR TITLE
Add custom server message autoresponder system to serverconfig

### DIFF
--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -283,13 +283,13 @@ class ServerConfig(commands.Cog):
         # TODO: fix stuff happening when active channel is none
         if not ctx.author.guild_permissions.manage_messages:
             return await ctx.respond("You can't use this command! You need the `Manage Messages` permission to run this.", ephemeral=True)
-        serverconf.add_autoresponder(
+        result_code = serverconf.add_autoresponder(
             ctx.guild.id,
             autoresponder_name=autoresponder_name,
             autoresponder_trigger=text_trigger,
             autoresponder_text=text_response,
             autoresponder_trigger_condition=trigger_condition,
-            channel=active_channel.id,
+            channel=active_channel.id if active_channel is not None else None,
             match_case=match_case
         )
         if result_code == 1:

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -264,6 +264,47 @@ class ServerConfig(commands.Cog):
             json.dump(self.verification_db, f, indent=4)
 
         return await ctx.respond(f"You have been successfully verified in **{vcode_guild.name}**!")
+    
+    # Autoresponder Configuration Commands
+    #autoresponder_commands = SlashCommandGroup(name="autoresponder", description="Commands related to the management of server text-based autoresponders.")
+
+    commands.slash_command(
+        name="autoresponder_add",
+        description="Add a new text-based autoresponder to your server."
+    )
+    @option(name="autoresponder_name", description="The name (id) of the autoresponder.", type=str)
+    @option(name="text_trigger", description="The text on which the autoresponder is triggered.", type=str)
+    @option(name="text_response", description="The response you want the bot to send, when triggered.", type=str)
+    @option(name="trigger_condition", description="MATCH_MESSAGE: The message content must be the same as the trigger; WITHIN_MESSAGE: When trigger is found anywhere within the message", type=str, choices=["MATCH_MESSAGE", "WITHIN_MESSAGE"])
+    @option(name="active_channel", description="In which channel do you want the autoresponder to be active?", type=discord.TextChannel, default=None)
+    @option(name="match_case", description="Do you want the trigger to be case-sensitive?", type=bool, default=False)
+    async def autoresponder_add(self, ctx: ApplicationContext, autoresponder_name: str, text_trigger: str, text_response: str, trigger_condition: str, active_channel: discord.TextChannel, match_case: bool):
+        """Add a new text-based autoresponder to your server."""
+        if not ctx.author.guild_permissions.manage_messages:
+            return await ctx.respond("You can't use this command! You need the `Manage Messages` permission to run this.", ephemeral=True)
+        serverconf.add_autoresponder(
+            ctx.guild.id,
+            autoresponder_name=autoresponder_name,
+            autoresponder_trigger=text_trigger,
+            autoresponder_text=text_response,
+            autoresponder_trigger_condition=trigger_condition,
+            channels=active_channel,
+            match_case=match_case
+        )
+        localembed = discord.Embed(
+            title=":white_check_mark: Autoresponder Successfully Created",
+            description=f"Autoresponder Name: `{autoresponder_name}`\n\nYou may use the autoresponder name to reference this autoresponder, for editing or deleting.",
+            color=discord.Color.green()
+        )
+        localembed.add_field(name="Text Trigger", value=text_trigger)
+        localembed.add_field(name="Bot Response", value=text_response)
+        localembed.add_field(name="Autoresponder Trigger Condition", value=trigger_condition)
+        if active_channel == None:
+            localembed.add_field(name="Active Channel", value="all channels")
+        else:
+            localembed.add_field(name="Active Channel", value=f"<#{active_channel.id}>")
+        localembed.add_field(name="Match Case?", value=match_case)
+        await ctx.respond(embed=localembed)
 
 def setup(bot):
     bot.add_cog(ServerConfig(bot))

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -278,7 +278,7 @@ class ServerConfig(commands.Cog):
     @option(name="trigger_condition", description="How do you want the autoresponder to be triggered?", type=str, choices=["MATCH_MESSAGE", "WITHIN_MESSAGE"])
     @option(name="active_channel", description="In which channel do you want the autoresponder to be active?", type=discord.TextChannel, default=None)
     @option(name="match_case", description="Do you want the trigger to be case-sensitive?", type=bool, default=False)
-    async def autoresponder_add(self, ctx: ApplicationContext, autoresponder_name: str, text_trigger: str, text_response: str, trigger_condition: str, active_channel: discord.TextChannel, match_case: bool):
+    async def autoresponder_add(self, ctx: ApplicationContext, autoresponder_name: str, text_trigger: str, text_response: str, trigger_condition: str, active_channel: discord.TextChannel = None, match_case: bool = False):
         """Add a new text-based autoresponder to your server."""
         if not ctx.author.guild_permissions.manage_messages:
             return await ctx.respond("You can't use this command! You need the `Manage Messages` permission to run this.", ephemeral=True)

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -275,7 +275,7 @@ class ServerConfig(commands.Cog):
     @option(name="autoresponder_name", description="The name (id) of the autoresponder.", type=str)
     @option(name="text_trigger", description="The text on which the autoresponder is triggered.", type=str)
     @option(name="text_response", description="The response you want the bot to send, when triggered.", type=str)
-    @option(name="trigger_condition", description="MATCH_MESSAGE: The message content must be the same as the trigger; WITHIN_MESSAGE: When trigger is found anywhere within the message", type=str, choices=["MATCH_MESSAGE", "WITHIN_MESSAGE"])
+    @option(name="trigger_condition", description="How do you want the autoresponder to be triggered?", type=str, choices=["MATCH_MESSAGE", "WITHIN_MESSAGE"])
     @option(name="active_channel", description="In which channel do you want the autoresponder to be active?", type=discord.TextChannel, default=None)
     @option(name="match_case", description="Do you want the trigger to be case-sensitive?", type=bool, default=False)
     async def autoresponder_add(self, ctx: ApplicationContext, autoresponder_name: str, text_trigger: str, text_response: str, trigger_condition: str, active_channel: discord.TextChannel, match_case: bool):

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -325,7 +325,13 @@ class ServerConfig(commands.Cog):
                 description=f"You don't have any autoresponders you can remove, let alone something with the name `{autoresponder_name}`.",
                 color=discord.Color.orange()
             )
-            await ctx.respond(embed=localembed)
+            return await ctx.respond(embed=localembed)
+        localembed = discord.Embed(
+            title=f":white_check_mark: Autoresponder `{autoresponder_name}` Successfully Removed",
+            description="The bot will now not respond to this autoresponder's trigger.",
+            color=discord.Color.green()
+        )
+        await ctx.respond(embed=localembed)
 
 def setup(bot):
     bot.add_cog(ServerConfig(bot))

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -305,6 +305,34 @@ class ServerConfig(commands.Cog):
             localembed.add_field(name="Active Channel", value=f"<#{active_channel.id}>")
         localembed.add_field(name="Match Case?", value=match_case)
         await ctx.respond(embed=localembed)
+    
+    commands.slash_command(
+        name="autoresponder_remove",
+        description="Remove an existing autoresponder from your server."
+    )
+    @option(name="autoresponder_name", description="The name of the autoresponder you want to remove.", type=str)
+    async def autoresponder_remove(self, ctx: ApplicationContext, autoresponder_name: str):
+        """Remove an existing autoresponder from your server."""
+        if not ctx.author.guild_permissions.manage_messages:
+            return await ctx.respond("You can't use this command! You need the `Manage Messages` permission to run this.", ephemeral=True)
+        result_code = serverconf.remove_autoresponder(ctx.guild.id, autoresponder_name)
+        if result_code == 0:
+            localembed = discord.Embed(
+                title=f":white_check_mark: Autoresponder `{autoresponder_name}` Successfully Removed",
+                description="The bot will now not respond to this autoresponder's trigger.",
+                color=discord.Color.green()
+            )
+            await ctx.respond(embed=localembed)
+        elif result_code == 1:
+            localembed = discord.Embed(title="Failed to Remove Autoresponder", description=f"You don't have an autoresponder set with the name `{autoresponder_name}`.", color=discord.Color.red())
+            await ctx.respond(embed=localembed)
+        elif result_code == 2:
+            localembed = discord.Embed(
+                title="No Autoresponders Set",
+                description=f"You don't have any autoresponders you can remove, let alone something with the name `{autoresponder_name}`.",
+                color=discord.Color.orange()
+            )
+            await ctx.respond(embed=localembed)
 
 def setup(bot):
     bot.add_cog(ServerConfig(bot))

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -316,16 +316,9 @@ class ServerConfig(commands.Cog):
         if not ctx.author.guild_permissions.manage_messages:
             return await ctx.respond("You can't use this command! You need the `Manage Messages` permission to run this.", ephemeral=True)
         result_code = serverconf.remove_autoresponder(ctx.guild.id, autoresponder_name)
-        if result_code == 0:
-            localembed = discord.Embed(
-                title=f":white_check_mark: Autoresponder `{autoresponder_name}` Successfully Removed",
-                description="The bot will now not respond to this autoresponder's trigger.",
-                color=discord.Color.green()
-            )
-            await ctx.respond(embed=localembed)
-        elif result_code == 1:
+        if result_code == 1:
             localembed = discord.Embed(title=":x: Failed to Remove Autoresponder", description=f"You don't have an autoresponder set with the name `{autoresponder_name}`.", color=discord.Color.red())
-            await ctx.respond(embed=localembed)
+            return await ctx.respond(embed=localembed)
         elif result_code == 2:
             localembed = discord.Embed(
                 title=":grey_question: No Autoresponders Set",

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -280,7 +280,6 @@ class ServerConfig(commands.Cog):
     @option(name="match_case", description="Do you want the trigger to be case-sensitive?", type=bool, default=False)
     async def autoresponder_add(self, ctx: ApplicationContext, autoresponder_name: str, text_trigger: str, text_response: str, trigger_condition: str, active_channel: discord.TextChannel = None, match_case: bool = False):
         """Add a new text-based autoresponder to your server."""
-        # TODO: fix stuff happening when active channel is none
         if not ctx.author.guild_permissions.manage_messages:
             return await ctx.respond("You can't use this command! You need the `Manage Messages` permission to run this.", ephemeral=True)
         result_code = serverconf.add_autoresponder(

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -268,7 +268,7 @@ class ServerConfig(commands.Cog):
     # Autoresponder Configuration Commands
     #autoresponder_commands = SlashCommandGroup(name="autoresponder", description="Commands related to the management of server text-based autoresponders.")
 
-    commands.slash_command(
+    @commands.slash_command(
         name="autoresponder_add",
         description="Add a new text-based autoresponder to your server."
     )
@@ -306,7 +306,7 @@ class ServerConfig(commands.Cog):
         localembed.add_field(name="Match Case?", value=match_case)
         await ctx.respond(embed=localembed)
     
-    commands.slash_command(
+    @commands.slash_command(
         name="autoresponder_remove",
         description="Remove an existing autoresponder from your server."
     )

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -387,9 +387,6 @@ class ServerConfig(commands.Cog):
                 localembed = discord.Embed(title=":x: No Autoresponder Found", description=f"You don't have an autoresponder set with the name `{autoresponder_name}`.", color=discord.Color.red())
                 return await ctx.respond(embed=localembed)
 
-                
-
-
 def setup(bot):
     bot.add_cog(ServerConfig(bot))
     

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -280,6 +280,7 @@ class ServerConfig(commands.Cog):
     @option(name="match_case", description="Do you want the trigger to be case-sensitive?", type=bool, default=False)
     async def autoresponder_add(self, ctx: ApplicationContext, autoresponder_name: str, text_trigger: str, text_response: str, trigger_condition: str, active_channel: discord.TextChannel = None, match_case: bool = False):
         """Add a new text-based autoresponder to your server."""
+        # TODO: fix stuff happening when active channel is none
         if not ctx.author.guild_permissions.manage_messages:
             return await ctx.respond("You can't use this command! You need the `Manage Messages` permission to run this.", ephemeral=True)
         serverconf.add_autoresponder(

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -292,6 +292,13 @@ class ServerConfig(commands.Cog):
             channel=active_channel.id,
             match_case=match_case
         )
+        if result_code == 1:
+            localembed = discord.Embed(
+                title=":warning: An Autoresponder Already Exists With This Name",
+                description="Try again using a different name, or remove the existing autoresponder and run this command again.",
+                color=discord.Color.orange()
+            )
+            return await ctx.respond(embed=localembed)
         localembed = discord.Embed(
             title=":white_check_mark: Autoresponder Successfully Created",
             description=f"Autoresponder Name: `{autoresponder_name}`\n\nYou may use the autoresponder name to reference this autoresponder, for editing or deleting.",

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -288,7 +288,7 @@ class ServerConfig(commands.Cog):
             autoresponder_trigger=text_trigger,
             autoresponder_text=text_response,
             autoresponder_trigger_condition=trigger_condition,
-            channels=active_channel,
+            channel=active_channel,
             match_case=match_case
         )
         localembed = discord.Embed(

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -324,11 +324,11 @@ class ServerConfig(commands.Cog):
             )
             await ctx.respond(embed=localembed)
         elif result_code == 1:
-            localembed = discord.Embed(title="Failed to Remove Autoresponder", description=f"You don't have an autoresponder set with the name `{autoresponder_name}`.", color=discord.Color.red())
+            localembed = discord.Embed(title=":x: Failed to Remove Autoresponder", description=f"You don't have an autoresponder set with the name `{autoresponder_name}`.", color=discord.Color.red())
             await ctx.respond(embed=localembed)
         elif result_code == 2:
             localembed = discord.Embed(
-                title="No Autoresponders Set",
+                title=":grey_question: No Autoresponders Set",
                 description=f"You don't have any autoresponders you can remove, let alone something with the name `{autoresponder_name}`.",
                 color=discord.Color.orange()
             )

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -288,7 +288,7 @@ class ServerConfig(commands.Cog):
             autoresponder_trigger=text_trigger,
             autoresponder_text=text_response,
             autoresponder_trigger_condition=trigger_condition,
-            channel=active_channel,
+            channel=active_channel.id,
             match_case=match_case
         )
         localembed = discord.Embed(

--- a/cogs/serverconfig.py
+++ b/cogs/serverconfig.py
@@ -266,9 +266,9 @@ class ServerConfig(commands.Cog):
         return await ctx.respond(f"You have been successfully verified in **{vcode_guild.name}**!")
     
     # Autoresponder Configuration Commands
-    #autoresponder_commands = SlashCommandGroup(name="autoresponder", description="Commands related to the management of server text-based autoresponders.")
+    autoresponder_commands = SlashCommandGroup(name="autoresponder", description="Commands related to the management of server text-based autoresponders.")
 
-    @commands.slash_command(
+    @autoresponder_commands.command(
         name="autoresponder_add",
         description="Add a new text-based autoresponder to your server."
     )
@@ -313,7 +313,7 @@ class ServerConfig(commands.Cog):
         localembed.add_field(name="Match Case?", value=match_case)
         await ctx.respond(embed=localembed)
     
-    @commands.slash_command(
+    @autoresponder_commands.command(
         name="autoresponder_remove",
         description="Remove an existing autoresponder from your server."
     )
@@ -340,7 +340,7 @@ class ServerConfig(commands.Cog):
         )
         await ctx.respond(embed=localembed)
     
-    @commands.slash_command(
+    @autoresponder_commands.command(
         name="autoresponder_list",
         description="View a list of all the autoresponders in the server, or info on a specific autoresponder."
     )

--- a/framework/isobot/db/serverconfig.py
+++ b/framework/isobot/db/serverconfig.py
@@ -35,9 +35,9 @@ class ServerConfig:
                 },
                 "level_up_override_channel": None,
                 "verification_role": None,
-                "autoresponder": [
+                "autoresponder": {
 
-                ]
+                }
             }
             self.save(serverconf)
         return 0

--- a/framework/isobot/db/serverconfig.py
+++ b/framework/isobot/db/serverconfig.py
@@ -36,7 +36,7 @@ class ServerConfig:
                 "level_up_override_channel": None,
                 "verification_role": None,
                 "autoresponder": [
-                    
+
                 ]
             }
             self.save(serverconf)
@@ -47,6 +47,7 @@ class ServerConfig:
         serverconf = self.load()
         return serverconf[str(server_id)]
     
+    # Fetch Functions
     def fetch_autorole(self, server_id: int) -> str:
         """Fetches the specified autorole for the server. Returns `None` if not set."""
         return self.fetch_raw(server_id)["autorole"]
@@ -67,6 +68,7 @@ class ServerConfig:
         """Fetches the verified member role for the specified guild. Returns `None` if server verification system is disabled."""
         return self.fetch_raw(server_id)["verification_role"]
 
+    # Set Functions
     def set_autorole(self, server_id: int, role_id: int) -> int:
         """Sets a role id to use as autorole for the specified guild. Returns `0` if successful."""
         serverconf = self.load()

--- a/framework/isobot/db/serverconfig.py
+++ b/framework/isobot/db/serverconfig.py
@@ -118,7 +118,7 @@ class ServerConfig:
         autoresponder_text: str,
         autoresponder_trigger_condition: str = Literal["MATCH_MESSAGE", "WITHIN_MESSAGE"],
         *,
-        channels: list = None,
+        channel: list = None,
         match_case: bool = False
     ):
         """Adds a new autoresponder configuration for the specified guild, with the provided configuration data. Returns `0` if successful.\n\nNotes: \n- `autoreponder_name` can be considered as autoresponder id."""
@@ -127,7 +127,7 @@ class ServerConfig:
             "autoresponder_trigger": autoresponder_trigger,
             "autoresponder_text": autoresponder_text,
             "autoresponder_trigger_condition": autoresponder_trigger_condition,
-            "active_channels": channels,
+            "active_channel": channel,
             "match_case": match_case
         }
         self.save(serverconf)

--- a/framework/isobot/db/serverconfig.py
+++ b/framework/isobot/db/serverconfig.py
@@ -34,7 +34,10 @@ class ServerConfig:
                     "message": None
                 },
                 "level_up_override_channel": None,
-                "verification_role": None
+                "verification_role": None,
+                "autoresponder": [
+                    
+                ]
             }
             self.save(serverconf)
         return 0

--- a/framework/isobot/db/serverconfig.py
+++ b/framework/isobot/db/serverconfig.py
@@ -121,16 +121,19 @@ class ServerConfig:
         channel: list = None,
         match_case: bool = False
     ):
-        """Adds a new autoresponder configuration for the specified guild, with the provided configuration data. Returns `0` if successful.\n\nNotes: \n- `autoreponder_name` can be considered as autoresponder id."""
+        """Adds a new autoresponder configuration for the specified guild, with the provided configuration data. Returns `0` if successful, returns `1` if configuration with same name already exists.\n\nNotes: \n- `autoreponder_name` can be considered as autoresponder id."""
         serverconf = self.load()
-        serverconf[str(server_id)]["autoresponder"][autoresponder_name] = {
-            "autoresponder_trigger": autoresponder_trigger,
-            "autoresponder_text": autoresponder_text,
-            "autoresponder_trigger_condition": autoresponder_trigger_condition,
-            "active_channel": channel,
-            "match_case": match_case
-        }
-        self.save(serverconf)
+        if autoresponder_name not in serverconf[str(server_id)]["autoresponder"].keys():
+            serverconf[str(server_id)]["autoresponder"][autoresponder_name] = {
+                "autoresponder_trigger": autoresponder_trigger,
+                "autoresponder_text": autoresponder_text,
+                "autoresponder_trigger_condition": autoresponder_trigger_condition,
+                "active_channel": channel,
+                "match_case": match_case
+            }
+            self.save(serverconf)
+            return 0
+        else: return 1
     
     def remove_autoresponder(self, server_id: Union[int, str], autoresponder_name: str):
         """Removes an existing autoresponder from the specified guild's serverconfig data. Returns `0` if successful, returns `1` if autoresponder does not exist, returns `2` if no autoresponders set up."""

--- a/main.py
+++ b/main.py
@@ -307,6 +307,26 @@ async def on_message(ctx):
                     # In that case isobot will automatically stop sending levelup messages to them
                     logger.warn(f"Unable to send level up message to {ctx.author} ({ctx.author.id}), as they are not accepting DMs from isobot. This ID has been added to `levelup_messages` blacklist.", module="main/Levelling")
                     settings.edit_setting(ctx.author.id, "levelup_messages", False)
+        
+        # Autoresponder System
+        server_autoresponder_config: dict = serverconfig.fetch_autoresponder_configuration(ctx.guild.id)
+
+        for config in server_autoresponder_config.keys():
+            if server_autoresponder_config[config]["active_channel"] == None or server_autoresponder_config[config]["active_channel"] == ctx.channel.id:
+                if server_autoresponder_config[config]["match_case"]:
+                    if server_autoresponder_config[config]["autoresponder_trigger_condition"] == "MATCH_MESSAGE":
+                        if ctx.content == server_autoresponder_config[config]["autoresponder_trigger"]:
+                            await ctx.channel.send(server_autoresponder_config[config]["autoresponder_text"])
+                    elif server_autoresponder_config[config]["autoresponder_trigger_condition"] == "WITHIN_MESSAGE":
+                        if server_autoresponder_config[config]["autoresponder_trigger"] in ctx.content:
+                            await ctx.channel.send(server_autoresponder_config[config]["autoresponder_text"])
+                else:
+                    if server_autoresponder_config[config]["autoresponder_trigger_condition"] == "MATCH_MESSAGE":
+                        if ctx.content.lower() == server_autoresponder_config[config]["autoresponder_trigger"]:
+                            await ctx.channel.send(server_autoresponder_config[config]["autoresponder_text"])
+                    elif server_autoresponder_config[config]["autoresponder_trigger_condition"] == "WITHIN_MESSAGE":
+                        if server_autoresponder_config[config]["autoresponder_trigger"] in ctx.content.lower():
+                            await ctx.channel.send(server_autoresponder_config[config]["autoresponder_text"])
 
 # Error handler
 @client.event


### PR DESCRIPTION
# 💬🔁 Autoresponder System
This allows server managers and owners to configure isobot (using serverconfig commands) to respond in a channel to certain messages from other users, with a custom response! 

You can set multiple autoresponders server-wide or limited to a specific channel, set whether the trigger is case-sensitive, as well as being choosing the trigger condition, either when a specific line of text is found in any message, or if the text matches the message content.

More features may be added soon to autoresponders (like response modes), so stay alert!

(autoresponders are configurable only by server members with the `Manage Messages` permission)