### PR TITLE
Add isobot light favicon to the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
 <html lang="en">
     <head>
         <title>isobot</title>
+        <link rel="icon favicon" href="https://pybotdevs.github.io/web/resources/isobot/light-favicon.png">
         <link rel="stylesheet" type="text/css" href="style.css">
         <link rel="shortcut icon" href="resources/nka_white.png">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
The isobot logo should now appear on your browser's page tab, if it's supported. (im sorry if you're on light mode)