### PR TITLE
Remove `(soon)` from the `Server Verification` item

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
                             <li>Moderation</li>
                             <li>Levelling</li>
                             <li>Automod</li>
-                            <li>Server Verification <sup>(soon)</sup></li>
+                            <li>Server Verification</li>
                             <li>Maths Commands</li>
                             <li>Fun Commands</li>
                             <li>ChatGPT and AI Image Generation Commands, and</li>


### PR DESCRIPTION
This is being done now since I recently added server verification as a new isobot feature. (this will be fully released in the next isobot release) 