### PR TITLE
Add network check and autorestart for failed bot client login

### DIFF
--- a/network_check.py
+++ b/network_check.py
@@ -1,0 +1,11 @@
+"""Checks the network status, by sending an HTTP request to Google's servers, and returns the status."""
+
+import requests
+
+def network_check() -> bool:
+    """Checks the network status, by sending an HTTP request to Google's servers, and returns the status."""
+    try:
+        requests.get("https://www.google.com", timeout=3)
+        return True
+    except requests.exceptions.ConnectionError:
+        return False


### PR DESCRIPTION
This update makes the client check for network connectivity before running the client completely, and keeps retrying until a network connection is established (useful for server environments).

This also checks for any network-related issues while logging in the bot client to Discord, and logs any network errors in the process. This system also gives the client 5 attempts to try to log in, after which the client automatically terminates.