### PR TITLE
Add superusers runtime option to default runtimeconfig in `initial_setup`

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -46,7 +46,8 @@ def initial_setup() -> Literal[0]:
         "ping_server_override": False,
         "debug_mode": False,
         "show_ping_on_startup": True,
-        "isocard_server_enabled": True
+        "isocard_server_enabled": True,
+        "superusers": []
     }
     for key in default_runtime_option_values:
         if key not in runtimeconfig_db["runtime_options"]:

--- a/cogs/devtools.py
+++ b/cogs/devtools.py
@@ -15,8 +15,6 @@ currency = CurrencyAPI(f"{client_data_dir}/database/currency.json", f"{client_da
 levelling = levelling.Levelling()
 
 # Bot Superusers List
-superusers = ["738290097170153472"]
-
 def fetch_superusers() -> list:
     """Fetches a list of all of the superusers' Discord IDs registered in isobot."""
     return list(auth.get_runtime_options["superusers"])

--- a/cogs/devtools.py
+++ b/cogs/devtools.py
@@ -1,6 +1,7 @@
 # Imports
 import discord
 import os
+from api import auth
 from framework.isobot.currency import CurrencyAPI
 from framework.isobot.db import levelling
 from discord import option, ApplicationContext, SlashCommandGroup
@@ -16,6 +17,10 @@ levelling = levelling.Levelling()
 # Bot Superusers List
 superusers = ["738290097170153472"]
 
+def fetch_superusers() -> list:
+    """Fetches a list of all of the superusers' Discord IDs registered in isobot."""
+    return list(auth.get_runtime_options["superusers"])
+
 # Commands
 class DevTools(commands.Cog):
     def __init__(self, bot):
@@ -30,7 +35,7 @@ class DevTools(commands.Cog):
     @option(name="user", description="Specify the user to change their balance", type=discord.User)
     @option(name="modifier", description="Specify the balance to modify", type=int)
     async def modify_balance(self, ctx: ApplicationContext, user: discord.User, modifier: int):
-        if str(ctx.author.id) not in superusers: return ctx.respond("This command is usable only by **developers** and **bot superusers**.", ephemeral=True)
+        if str(ctx.author.id) not in fetch_superusers(): return ctx.respond("This command is usable only by **developers** and **bot superusers**.", ephemeral=True)
         try:
             currency.add(user.id, modifier)
             await ctx.respond(f"{user.name}\'s balance has been modified by {modifier} coins.\n\n**New Balance:** {currency.get_wallet(user.id)} coins", ephemeral=True)
@@ -43,7 +48,7 @@ class DevTools(commands.Cog):
     @option(name="user", description="Who's rank do you want to edit?", type=discord.User)
     @option(name="new_rank", description="The new rank you want to set for the user", type=int)
     async def edit_rank(self, ctx: ApplicationContext, user: discord.User, new_rank: int):
-        if str(ctx.author.id) not in superusers: return await ctx.respond("This command is usable only by **developers** and **bot superusers**.", ephemeral=True)
+        if str(ctx.author.id) not in fetch_superusers(): return await ctx.respond("This command is usable only by **developers** and **bot superusers**.", ephemeral=True)
         try:
             levelling.set_level(user.id, new_rank)
             await ctx.respond(f"{user.display_name}\'s rank successfully edited. `New Rank: {levelling.get_level(user.id)}`")
@@ -56,7 +61,7 @@ class DevTools(commands.Cog):
     @option(name="user", description="Who's rank do you want to edit?", type=discord.User)
     @option(name="new_xp", description="The new xp count you want to set for the user", type=int)
     async def edit_xp(self, ctx: ApplicationContext, user: discord.User, new_xp: int):
-        if str(ctx.author.id) not in superusers: return await ctx.respond("This command is usable only by **developers** and **bot superusers**.", ephemeral=True)
+        if str(ctx.author.id) not in fetch_superusers(): return await ctx.respond("This command is usable only by **developers** and **bot superusers**.", ephemeral=True)
         try:
             levelling.set_xp(user.id, new_xp)
             await ctx.respond(f"{user.display_name}\'s XP count successfully edited. `New XP: {levelling.get_xp(user.id)}`")


### PR DESCRIPTION
The `superusers` option is a list which can contain an infinite number of Discord user IDs.

Every single user ID present in this runtimeconfig option will have unrestricted access to all internal devtools commands.