### PR TITLE
Make bot shutdown command (for developers)

### DIFF
--- a/main.py
+++ b/main.py
@@ -555,6 +555,18 @@ async def reload(ctx: ApplicationContext, cog: str):
             )
         )
 
+# Core Developer Commands
+@client.slash_command(
+    name="shutdown",
+    description="Shut down the bot as a developer."
+)
+async def shutdown(ctx: ApplicationContext):
+    """Shut down the bot as a developer."""
+    if ctx.author.id != 738290097170153472:
+        return await ctx.respond("You can't use this command!", ephemeral=True)
+    ctx.respond(":sleeping: Acknowledged. Isobot will now shut down.")
+    raise SystemExit
+
 # Settings commands
 config = client.create_group("settings", "Commands used to change bot settings.")
 


### PR DESCRIPTION
I don't wanna have to risk stuff every time when trying to unplug my server, whether the bot is still saving data or not. Its almost like a game of russian roulette at that point. I just don't wanna risk it anymore with that.